### PR TITLE
refactor(testing): remove expectTokenSequence() and perform custom co…

### DIFF
--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -7,16 +7,49 @@ import (
 	"github.com/xjslang/xjs/token"
 )
 
-func expectTokenSequence(t *testing.T, input string, expectedToks []token.Token) {
-	l := New(strings.NewReader(input))
+func TestAfterNewline(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"newline before block comment", "hello\n/* block comment */world"},
+		{"block comment with newline", "hello/* block\ncomment */world"},
+		{"newline", "hello\nworld"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			expectedToks := []token.Token{
+				{Type: token.IDENT, Literal: "hello"},
+				{Type: token.IDENT, Literal: "world", AfterNewline: true},
+			}
+			l := New(strings.NewReader(test.input))
+			for i, expectedTok := range expectedToks {
+				tok := l.NextToken()
+				if tok.Type != expectedTok.Type {
+					t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+				} else if tok.Literal != expectedTok.Literal {
+					t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+				} else if tok.AfterNewline != expectedTok.AfterNewline {
+					t.Errorf("token %d: expected AfterNewline to be %t, got %t", i, expectedTok.AfterNewline, tok.AfterNewline)
+				}
+			}
+		})
+	}
+}
+
+func TestEmptySinglelineComment(t *testing.T) {
+	expectedToks := []token.Token{
+		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []string{""}},
+		{Type: token.IDENT, Literal: "there", LeadingTrivia: []string{""}},
+		{Type: token.EOF, LeadingTrivia: []string{"\rObi-Wan Kenobi"}},
+	}
+	l := New(strings.NewReader("//\nhello//\r\nthere//\rObi-Wan Kenobi"))
 	for i, expectedTok := range expectedToks {
 		tok := l.NextToken()
 		if tok.Type != expectedTok.Type {
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
 		} else if tok.Literal != expectedTok.Literal {
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		} else if tok.AfterNewline != expectedTok.AfterNewline {
-			t.Errorf("token %d: expected AfterNewline to be %t, got %t", i, expectedTok.AfterNewline, tok.AfterNewline)
 		} else if expectedTok.LeadingTrivia != nil && len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia) {
 			t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
 		} else {
@@ -29,70 +62,86 @@ func expectTokenSequence(t *testing.T, input string, expectedToks []token.Token)
 	}
 }
 
-func TestAfterNewline(t *testing.T) {
-	tests := []struct {
-		name  string
-		input string
-	}{
-		{"newline before block comment", "hello\n/* block comment */world"},
-		{"block comment with newline", "hello/* block\ncomment */world"},
-		{"newline", "hello\nworld"},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			expectTokenSequence(t, test.input, []token.Token{
-				{Type: token.IDENT, Literal: "hello"},
-				{Type: token.IDENT, Literal: "world", AfterNewline: true},
-			})
-		})
-	}
-}
-
-func TestEmptySinglelineComment(t *testing.T) {
-	expectTokenSequence(t, "//\nhello//\r\nthere//\rObi-Wan Kenobi", []token.Token{
-		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []string{""}, AfterNewline: true},
-		{Type: token.IDENT, Literal: "there", LeadingTrivia: []string{""}, AfterNewline: true},
-		{Type: token.EOF, LeadingTrivia: []string{"\rObi-Wan Kenobi"}, AfterNewline: true},
-	})
-}
-
 func TestMultilineComments(t *testing.T) {
-	expectTokenSequence(t, `/* lorem
+	expectedToks := []token.Token{
+		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []string{" lorem\nipsum dolor ", "", ""}},
+		{Type: token.ILLEGAL, Literal: " unfinished comment"},
+		{Type: token.EOF},
+	}
+	l := New(strings.NewReader(`/* lorem
 ipsum dolor */
 
-hello/* unfinished comment`, []token.Token{
-		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []string{" lorem\nipsum dolor ", "", ""}, AfterNewline: true},
-		{Type: token.ILLEGAL, Literal: " unfinished comment", AfterNewline: false},
-		{Type: token.EOF},
-	})
+hello/* unfinished comment`))
+	for i, expectedTok := range expectedToks {
+		tok := l.NextToken()
+		if tok.Type != expectedTok.Type {
+			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+		} else if tok.Literal != expectedTok.Literal {
+			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+		} else if expectedTok.LeadingTrivia != nil && len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia) {
+			t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
+		} else {
+			for j, line := range expectedTok.LeadingTrivia {
+				if tok.LeadingTrivia[j] != line {
+					t.Errorf("token %d: expected %q leading trivia line, got %q", i, line, tok.LeadingTrivia[j])
+				}
+			}
+		}
+	}
 }
 
 func TestSinglelineComments(t *testing.T) {
-	expectTokenSequence(t, `
+	expectedToks := []token.Token{
+		{Type: token.IDENT, Literal: "John", LeadingTrivia: []string{"", " First Name"}},
+		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: []string{"", "", " Last Name"}},
+		{Type: token.EOF, LeadingTrivia: []string{"", "", " Final comment"}},
+	}
+	l := New(strings.NewReader(`
   // First Name
   John
   
   // Last Name
   Smith
 	
-	// Final comment`, []token.Token{
-		{Type: token.IDENT, Literal: "John", LeadingTrivia: []string{"", " First Name"}, AfterNewline: true},
-		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: []string{"", "", " Last Name"}, AfterNewline: true},
-		{Type: token.EOF, LeadingTrivia: []string{"", "", " Final comment"}, AfterNewline: true},
-	})
+	// Final comment`))
+	for i, expectedTok := range expectedToks {
+		tok := l.NextToken()
+		if tok.Type != expectedTok.Type {
+			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+		} else if tok.Literal != expectedTok.Literal {
+			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+		} else if expectedTok.LeadingTrivia != nil && len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia) {
+			t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
+		} else {
+			for j, line := range expectedTok.LeadingTrivia {
+				if tok.LeadingTrivia[j] != line {
+					t.Errorf("token %d: expected %q leading trivia line, got %q", i, line, tok.LeadingTrivia[j])
+				}
+			}
+		}
+	}
 }
 
 func TestScanContinuesAfterNullCharacter(t *testing.T) {
-	expectTokenSequence(t, "Hello\x00World", []token.Token{
+	expectedToks := []token.Token{
 		{Type: token.IDENT, Literal: "Hello"},
 		{Type: token.UNKNOWN, Literal: "\x00"},
 		{Type: token.IDENT, Literal: "World"},
 		{Type: token.EOF},
-	})
+	}
+	l := New(strings.NewReader("Hello\x00World"))
+	for i, expectedTok := range expectedToks {
+		tok := l.NextToken()
+		if tok.Type != expectedTok.Type {
+			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+		} else if tok.Literal != expectedTok.Literal {
+			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+		}
+	}
 }
 
 func TestPunctuators(t *testing.T) {
-	expectTokenSequence(t, "; = == ! != < <= > >= () {} /", []token.Token{
+	expectedToks := []token.Token{
 		{Type: token.SEMICOLON, Literal: ";"},
 		{Type: token.ASSIGN, Literal: "="},
 		{Type: token.EQ, Literal: "=="},
@@ -108,57 +157,111 @@ func TestPunctuators(t *testing.T) {
 		{Type: token.RBRACE, Literal: "}"},
 		{Type: token.DIVIDE, Literal: "/"},
 		{Type: token.EOF},
-	})
+	}
+	l := New(strings.NewReader("; = == ! != < <= > >= () {} /"))
+	for i, expectedTok := range expectedToks {
+		tok := l.NextToken()
+		if tok.Type != expectedTok.Type {
+			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+		} else if tok.Literal != expectedTok.Literal {
+			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+		}
+	}
 }
 
 func TestSkipWhitespaces(t *testing.T) {
-	expectTokenSequence(t, "  one\ntwo\rthree\tfour \r\n five ", []token.Token{
+	expectedToks := []token.Token{
 		{Type: token.IDENT, Literal: "one"},
-		{Type: token.IDENT, Literal: "two", AfterNewline: true},
+		{Type: token.IDENT, Literal: "two"},
 		{Type: token.IDENT, Literal: "three"},
 		{Type: token.IDENT, Literal: "four"},
-		{Type: token.IDENT, Literal: "five", AfterNewline: true},
+		{Type: token.IDENT, Literal: "five"},
 		{Type: token.EOF},
-	})
+	}
+	l := New(strings.NewReader("  one\ntwo\rthree\tfour \r\n five "))
+	for i, expectedTok := range expectedToks {
+		tok := l.NextToken()
+		if tok.Type != expectedTok.Type {
+			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+		} else if tok.Literal != expectedTok.Literal {
+			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+		}
+	}
 }
 
-func TestReadIden(t *testing.T) {
-	expectTokenSequence(t, " hello  hello123   _hello123 ", []token.Token{
+func TestReadIdent(t *testing.T) {
+	expectedToks := []token.Token{
 		{Type: token.IDENT, Literal: "hello"},
 		{Type: token.IDENT, Literal: "hello123"},
 		{Type: token.IDENT, Literal: "_hello123"},
 		{Type: token.EOF},
-	})
+	}
+	l := New(strings.NewReader(" hello  hello123   _hello123 "))
+	for i, expectedTok := range expectedToks {
+		tok := l.NextToken()
+		if tok.Type != expectedTok.Type {
+			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+		} else if tok.Literal != expectedTok.Literal {
+			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+		}
+	}
 }
 
 func TestReadNumber(t *testing.T) {
-	expectTokenSequence(t, "123", []token.Token{
+	expectedToks := []token.Token{
 		{Type: token.NUMBER, Literal: "123"},
 		{Type: token.EOF},
-	})
+	}
+	l := New(strings.NewReader("123"))
+	for i, expectedTok := range expectedToks {
+		tok := l.NextToken()
+		if tok.Type != expectedTok.Type {
+			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+		} else if tok.Literal != expectedTok.Literal {
+			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+		}
+	}
 }
 
 func TestReadString(t *testing.T) {
 	t.Run("legal string", func(t *testing.T) {
-		expectTokenSequence(t, " 'Hello, World!' \"Hello, World!\"", []token.Token{
+		expectedToks := []token.Token{
 			{Type: token.STRING, Literal: "'Hello, World!'"},
 			{Type: token.STRING, Literal: "\"Hello, World!\""},
 			{Type: token.EOF},
-		})
+		}
+		l := New(strings.NewReader(" 'Hello, World!' \"Hello, World!\""))
+		for i, expectedTok := range expectedToks {
+			tok := l.NextToken()
+			if tok.Type != expectedTok.Type {
+				t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+			} else if tok.Literal != expectedTok.Literal {
+				t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+			}
+		}
 	})
 	t.Run("illegal string", func(t *testing.T) {
-		items := []string{
+		inputs := []string{
 			"'Hello, World",  // missing '
 			"'",              // missing '
 			"\"Hello, World", // missing "
 			"\"",             // missing "
 		}
-		expectTokenSequence(t, strings.Join(items, "\n"), []token.Token{
-			{Type: token.ILLEGAL, Literal: "'Hello, World", AfterNewline: false},
-			{Type: token.ILLEGAL, Literal: "'", AfterNewline: true},
-			{Type: token.ILLEGAL, Literal: "\"Hello, World", AfterNewline: true},
-			{Type: token.ILLEGAL, Literal: "\"", AfterNewline: true},
+		expectedToks := []token.Token{
+			{Type: token.ILLEGAL, Literal: "'Hello, World"},
+			{Type: token.ILLEGAL, Literal: "'"},
+			{Type: token.ILLEGAL, Literal: "\"Hello, World"},
+			{Type: token.ILLEGAL, Literal: "\""},
 			{Type: token.EOF},
-		})
+		}
+		l := New(strings.NewReader(strings.Join(inputs, "\n")))
+		for i, expectedTok := range expectedToks {
+			tok := l.NextToken()
+			if tok.Type != expectedTok.Type {
+				t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+			} else if tok.Literal != expectedTok.Literal {
+				t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+			}
+		}
 	})
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -25,11 +25,12 @@ func TestAfterNewline(t *testing.T) {
 			l := New(strings.NewReader(test.input))
 			for i, expectedTok := range expectedToks {
 				tok := l.NextToken()
-				if tok.Type != expectedTok.Type {
+				switch {
+				case tok.Type != expectedTok.Type:
 					t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-				} else if tok.Literal != expectedTok.Literal {
+				case tok.Literal != expectedTok.Literal:
 					t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-				} else if tok.AfterNewline != expectedTok.AfterNewline {
+				case tok.AfterNewline != expectedTok.AfterNewline:
 					t.Errorf("token %d: expected AfterNewline to be %t, got %t", i, expectedTok.AfterNewline, tok.AfterNewline)
 				}
 			}
@@ -46,13 +47,14 @@ func TestEmptySinglelineComment(t *testing.T) {
 	l := New(strings.NewReader("//\nhello//\r\nthere//\rObi-Wan Kenobi"))
 	for i, expectedTok := range expectedToks {
 		tok := l.NextToken()
-		if tok.Type != expectedTok.Type {
+		switch {
+		case tok.Type != expectedTok.Type:
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		} else if tok.Literal != expectedTok.Literal {
+		case tok.Literal != expectedTok.Literal:
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		} else if expectedTok.LeadingTrivia != nil && len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia) {
+		case len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia):
 			t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
-		} else {
+		default:
 			for j, line := range expectedTok.LeadingTrivia {
 				if tok.LeadingTrivia[j] != line {
 					t.Errorf("token %d: expected %q leading trivia line, got %q", i, line, tok.LeadingTrivia[j])
@@ -74,13 +76,14 @@ ipsum dolor */
 hello/* unfinished comment`))
 	for i, expectedTok := range expectedToks {
 		tok := l.NextToken()
-		if tok.Type != expectedTok.Type {
+		switch {
+		case tok.Type != expectedTok.Type:
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		} else if tok.Literal != expectedTok.Literal {
+		case tok.Literal != expectedTok.Literal:
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		} else if expectedTok.LeadingTrivia != nil && len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia) {
+		case len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia):
 			t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
-		} else {
+		default:
 			for j, line := range expectedTok.LeadingTrivia {
 				if tok.LeadingTrivia[j] != line {
 					t.Errorf("token %d: expected %q leading trivia line, got %q", i, line, tok.LeadingTrivia[j])
@@ -106,13 +109,14 @@ func TestSinglelineComments(t *testing.T) {
 	// Final comment`))
 	for i, expectedTok := range expectedToks {
 		tok := l.NextToken()
-		if tok.Type != expectedTok.Type {
+		switch {
+		case tok.Type != expectedTok.Type:
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		} else if tok.Literal != expectedTok.Literal {
+		case tok.Literal != expectedTok.Literal:
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		} else if expectedTok.LeadingTrivia != nil && len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia) {
+		case len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia):
 			t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
-		} else {
+		default:
 			for j, line := range expectedTok.LeadingTrivia {
 				if tok.LeadingTrivia[j] != line {
 					t.Errorf("token %d: expected %q leading trivia line, got %q", i, line, tok.LeadingTrivia[j])
@@ -132,9 +136,10 @@ func TestScanContinuesAfterNullCharacter(t *testing.T) {
 	l := New(strings.NewReader("Hello\x00World"))
 	for i, expectedTok := range expectedToks {
 		tok := l.NextToken()
-		if tok.Type != expectedTok.Type {
+		switch {
+		case tok.Type != expectedTok.Type:
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		} else if tok.Literal != expectedTok.Literal {
+		case tok.Literal != expectedTok.Literal:
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
 		}
 	}
@@ -161,9 +166,10 @@ func TestPunctuators(t *testing.T) {
 	l := New(strings.NewReader("; = == ! != < <= > >= () {} /"))
 	for i, expectedTok := range expectedToks {
 		tok := l.NextToken()
-		if tok.Type != expectedTok.Type {
+		switch {
+		case tok.Type != expectedTok.Type:
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		} else if tok.Literal != expectedTok.Literal {
+		case tok.Literal != expectedTok.Literal:
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
 		}
 	}
@@ -181,9 +187,10 @@ func TestSkipWhitespaces(t *testing.T) {
 	l := New(strings.NewReader("  one\ntwo\rthree\tfour \r\n five "))
 	for i, expectedTok := range expectedToks {
 		tok := l.NextToken()
-		if tok.Type != expectedTok.Type {
+		switch {
+		case tok.Type != expectedTok.Type:
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		} else if tok.Literal != expectedTok.Literal {
+		case tok.Literal != expectedTok.Literal:
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
 		}
 	}
@@ -199,9 +206,10 @@ func TestReadIdent(t *testing.T) {
 	l := New(strings.NewReader(" hello  hello123   _hello123 "))
 	for i, expectedTok := range expectedToks {
 		tok := l.NextToken()
-		if tok.Type != expectedTok.Type {
+		switch {
+		case tok.Type != expectedTok.Type:
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		} else if tok.Literal != expectedTok.Literal {
+		case tok.Literal != expectedTok.Literal:
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
 		}
 	}
@@ -215,9 +223,10 @@ func TestReadNumber(t *testing.T) {
 	l := New(strings.NewReader("123"))
 	for i, expectedTok := range expectedToks {
 		tok := l.NextToken()
-		if tok.Type != expectedTok.Type {
+		switch {
+		case tok.Type != expectedTok.Type:
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		} else if tok.Literal != expectedTok.Literal {
+		case tok.Literal != expectedTok.Literal:
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
 		}
 	}
@@ -233,9 +242,10 @@ func TestReadString(t *testing.T) {
 		l := New(strings.NewReader(" 'Hello, World!' \"Hello, World!\""))
 		for i, expectedTok := range expectedToks {
 			tok := l.NextToken()
-			if tok.Type != expectedTok.Type {
+			switch {
+			case tok.Type != expectedTok.Type:
 				t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-			} else if tok.Literal != expectedTok.Literal {
+			case tok.Literal != expectedTok.Literal:
 				t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
 			}
 		}
@@ -257,9 +267,10 @@ func TestReadString(t *testing.T) {
 		l := New(strings.NewReader(strings.Join(inputs, "\n")))
 		for i, expectedTok := range expectedToks {
 			tok := l.NextToken()
-			if tok.Type != expectedTok.Type {
+			switch {
+			case tok.Type != expectedTok.Type:
 				t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-			} else if tok.Literal != expectedTok.Literal {
+			case tok.Literal != expectedTok.Literal:
 				t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
 			}
 		}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -7,6 +7,54 @@ import (
 	"github.com/xjslang/xjs/token"
 )
 
+type tokenCompareConfig struct {
+	afterNewline  bool
+	leadingTrivia bool
+}
+
+type tokenCompareOption func(cfg *tokenCompareConfig)
+
+func compareAfterNewline() tokenCompareOption {
+	return func(cfg *tokenCompareConfig) {
+		cfg.afterNewline = true
+	}
+}
+
+func compareLeadingTrivia() tokenCompareOption {
+	return func(cfg *tokenCompareConfig) {
+		cfg.leadingTrivia = true
+	}
+}
+
+func assertTokens(t *testing.T, input string, expectedToks []token.Token, opts ...tokenCompareOption) {
+	cfg := &tokenCompareConfig{}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	l := New(strings.NewReader(input))
+	for i, expectedTok := range expectedToks {
+		tok := l.NextToken()
+		switch {
+		case tok.Type != expectedTok.Type:
+			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
+		case tok.Literal != expectedTok.Literal:
+			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
+		case cfg.afterNewline && tok.AfterNewline != expectedTok.AfterNewline:
+			t.Errorf("token %d: expected AfterNewline to be %t, got %t", i, expectedTok.AfterNewline, tok.AfterNewline)
+		case cfg.leadingTrivia:
+			if len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia) {
+				t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
+			} else {
+				for j, line := range expectedTok.LeadingTrivia {
+					if tok.LeadingTrivia[j] != line {
+						t.Errorf("token %d: expected %q leading trivia line, got %q", i, line, tok.LeadingTrivia[j])
+					}
+				}
+			}
+		}
+	}
+}
+
 func TestAfterNewline(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -14,139 +62,66 @@ func TestAfterNewline(t *testing.T) {
 	}{
 		{"newline before block comment", "hello\n/* block comment */world"},
 		{"block comment with newline", "hello/* block\ncomment */world"},
+		{"single-line comment", "hello// comment\nworld"},
 		{"newline", "hello\nworld"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			expectedToks := []token.Token{
+			assertTokens(t, test.input, []token.Token{
 				{Type: token.IDENT, Literal: "hello"},
 				{Type: token.IDENT, Literal: "world", AfterNewline: true},
-			}
-			l := New(strings.NewReader(test.input))
-			for i, expectedTok := range expectedToks {
-				tok := l.NextToken()
-				switch {
-				case tok.Type != expectedTok.Type:
-					t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-				case tok.Literal != expectedTok.Literal:
-					t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-				case tok.AfterNewline != expectedTok.AfterNewline:
-					t.Errorf("token %d: expected AfterNewline to be %t, got %t", i, expectedTok.AfterNewline, tok.AfterNewline)
-				}
-			}
+			}, compareAfterNewline())
 		})
 	}
 }
 
 func TestEmptySinglelineComment(t *testing.T) {
-	expectedToks := []token.Token{
+	assertTokens(t, "//\nhello//\r\nthere//\rObi-Wan Kenobi", []token.Token{
 		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []string{""}},
 		{Type: token.IDENT, Literal: "there", LeadingTrivia: []string{""}},
 		{Type: token.EOF, LeadingTrivia: []string{"\rObi-Wan Kenobi"}},
-	}
-	l := New(strings.NewReader("//\nhello//\r\nthere//\rObi-Wan Kenobi"))
-	for i, expectedTok := range expectedToks {
-		tok := l.NextToken()
-		switch {
-		case tok.Type != expectedTok.Type:
-			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		case tok.Literal != expectedTok.Literal:
-			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		case len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia):
-			t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
-		default:
-			for j, line := range expectedTok.LeadingTrivia {
-				if tok.LeadingTrivia[j] != line {
-					t.Errorf("token %d: expected %q leading trivia line, got %q", i, line, tok.LeadingTrivia[j])
-				}
-			}
-		}
-	}
+	}, compareLeadingTrivia())
 }
 
 func TestMultilineComments(t *testing.T) {
-	expectedToks := []token.Token{
+	input := `/* lorem
+ipsum dolor */
+
+hello/* unfinished comment`
+	assertTokens(t, input, []token.Token{
 		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []string{" lorem\nipsum dolor ", "", ""}},
 		{Type: token.ILLEGAL, Literal: " unfinished comment"},
 		{Type: token.EOF},
-	}
-	l := New(strings.NewReader(`/* lorem
-ipsum dolor */
-
-hello/* unfinished comment`))
-	for i, expectedTok := range expectedToks {
-		tok := l.NextToken()
-		switch {
-		case tok.Type != expectedTok.Type:
-			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		case tok.Literal != expectedTok.Literal:
-			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		case len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia):
-			t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
-		default:
-			for j, line := range expectedTok.LeadingTrivia {
-				if tok.LeadingTrivia[j] != line {
-					t.Errorf("token %d: expected %q leading trivia line, got %q", i, line, tok.LeadingTrivia[j])
-				}
-			}
-		}
-	}
+	}, compareLeadingTrivia())
 }
 
 func TestSinglelineComments(t *testing.T) {
-	expectedToks := []token.Token{
-		{Type: token.IDENT, Literal: "John", LeadingTrivia: []string{"", " First Name"}},
-		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: []string{"", "", " Last Name"}},
-		{Type: token.EOF, LeadingTrivia: []string{"", "", " Final comment"}},
-	}
-	l := New(strings.NewReader(`
+	input := `
   // First Name
   John
   
   // Last Name
   Smith
 	
-	// Final comment`))
-	for i, expectedTok := range expectedToks {
-		tok := l.NextToken()
-		switch {
-		case tok.Type != expectedTok.Type:
-			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		case tok.Literal != expectedTok.Literal:
-			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		case len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia):
-			t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
-		default:
-			for j, line := range expectedTok.LeadingTrivia {
-				if tok.LeadingTrivia[j] != line {
-					t.Errorf("token %d: expected %q leading trivia line, got %q", i, line, tok.LeadingTrivia[j])
-				}
-			}
-		}
-	}
+	// Final comment`
+	assertTokens(t, input, []token.Token{
+		{Type: token.IDENT, Literal: "John", LeadingTrivia: []string{"", " First Name"}},
+		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: []string{"", "", " Last Name"}},
+		{Type: token.EOF, LeadingTrivia: []string{"", "", " Final comment"}},
+	}, compareLeadingTrivia())
 }
 
 func TestScanContinuesAfterNullCharacter(t *testing.T) {
-	expectedToks := []token.Token{
+	assertTokens(t, "Hello\x00World", []token.Token{
 		{Type: token.IDENT, Literal: "Hello"},
 		{Type: token.UNKNOWN, Literal: "\x00"},
 		{Type: token.IDENT, Literal: "World"},
 		{Type: token.EOF},
-	}
-	l := New(strings.NewReader("Hello\x00World"))
-	for i, expectedTok := range expectedToks {
-		tok := l.NextToken()
-		switch {
-		case tok.Type != expectedTok.Type:
-			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		case tok.Literal != expectedTok.Literal:
-			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		}
-	}
+	})
 }
 
 func TestPunctuators(t *testing.T) {
-	expectedToks := []token.Token{
+	assertTokens(t, "; = == ! != < <= > >= () {} /", []token.Token{
 		{Type: token.SEMICOLON, Literal: ";"},
 		{Type: token.ASSIGN, Literal: "="},
 		{Type: token.EQ, Literal: "=="},
@@ -162,93 +137,43 @@ func TestPunctuators(t *testing.T) {
 		{Type: token.RBRACE, Literal: "}"},
 		{Type: token.DIVIDE, Literal: "/"},
 		{Type: token.EOF},
-	}
-	l := New(strings.NewReader("; = == ! != < <= > >= () {} /"))
-	for i, expectedTok := range expectedToks {
-		tok := l.NextToken()
-		switch {
-		case tok.Type != expectedTok.Type:
-			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		case tok.Literal != expectedTok.Literal:
-			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		}
-	}
+	})
 }
 
 func TestSkipWhitespaces(t *testing.T) {
-	expectedToks := []token.Token{
+	assertTokens(t, "  one\ntwo\rthree\tfour \r\n five ", []token.Token{
 		{Type: token.IDENT, Literal: "one"},
 		{Type: token.IDENT, Literal: "two"},
 		{Type: token.IDENT, Literal: "three"},
 		{Type: token.IDENT, Literal: "four"},
 		{Type: token.IDENT, Literal: "five"},
 		{Type: token.EOF},
-	}
-	l := New(strings.NewReader("  one\ntwo\rthree\tfour \r\n five "))
-	for i, expectedTok := range expectedToks {
-		tok := l.NextToken()
-		switch {
-		case tok.Type != expectedTok.Type:
-			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		case tok.Literal != expectedTok.Literal:
-			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		}
-	}
+	})
 }
 
 func TestReadIdent(t *testing.T) {
-	expectedToks := []token.Token{
+	assertTokens(t, " hello  hello123   _hello123 ", []token.Token{
 		{Type: token.IDENT, Literal: "hello"},
 		{Type: token.IDENT, Literal: "hello123"},
 		{Type: token.IDENT, Literal: "_hello123"},
 		{Type: token.EOF},
-	}
-	l := New(strings.NewReader(" hello  hello123   _hello123 "))
-	for i, expectedTok := range expectedToks {
-		tok := l.NextToken()
-		switch {
-		case tok.Type != expectedTok.Type:
-			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		case tok.Literal != expectedTok.Literal:
-			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		}
-	}
+	})
 }
 
 func TestReadNumber(t *testing.T) {
-	expectedToks := []token.Token{
+	assertTokens(t, "123", []token.Token{
 		{Type: token.NUMBER, Literal: "123"},
 		{Type: token.EOF},
-	}
-	l := New(strings.NewReader("123"))
-	for i, expectedTok := range expectedToks {
-		tok := l.NextToken()
-		switch {
-		case tok.Type != expectedTok.Type:
-			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-		case tok.Literal != expectedTok.Literal:
-			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		}
-	}
+	})
 }
 
 func TestReadString(t *testing.T) {
 	t.Run("legal string", func(t *testing.T) {
-		expectedToks := []token.Token{
+		assertTokens(t, " 'Hello, World!' \"Hello, World!\"", []token.Token{
 			{Type: token.STRING, Literal: "'Hello, World!'"},
 			{Type: token.STRING, Literal: "\"Hello, World!\""},
 			{Type: token.EOF},
-		}
-		l := New(strings.NewReader(" 'Hello, World!' \"Hello, World!\""))
-		for i, expectedTok := range expectedToks {
-			tok := l.NextToken()
-			switch {
-			case tok.Type != expectedTok.Type:
-				t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-			case tok.Literal != expectedTok.Literal:
-				t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-			}
-		}
+		})
 	})
 	t.Run("illegal string", func(t *testing.T) {
 		inputs := []string{
@@ -257,22 +182,12 @@ func TestReadString(t *testing.T) {
 			"\"Hello, World", // missing "
 			"\"",             // missing "
 		}
-		expectedToks := []token.Token{
+		assertTokens(t, strings.Join(inputs, "\n"), []token.Token{
 			{Type: token.ILLEGAL, Literal: "'Hello, World"},
 			{Type: token.ILLEGAL, Literal: "'"},
 			{Type: token.ILLEGAL, Literal: "\"Hello, World"},
 			{Type: token.ILLEGAL, Literal: "\""},
 			{Type: token.EOF},
-		}
-		l := New(strings.NewReader(strings.Join(inputs, "\n")))
-		for i, expectedTok := range expectedToks {
-			tok := l.NextToken()
-			switch {
-			case tok.Type != expectedTok.Type:
-				t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
-			case tok.Literal != expectedTok.Literal:
-				t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-			}
-		}
+		})
 	})
 }


### PR DESCRIPTION
…mparisons instead

The purpose of this pull request is to compare only the fields involved, not all fields. For example, `TestAfterNewline` is the only test where I'm interested in verifying that the `AfterNewline` fields have correct values, but not in the other tests.