### PR TITLE
refactor(lexer): treat CR as a newline

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -70,7 +70,7 @@ triviaLoop:
 }
 
 func (l *Lexer) skipWhitespaces() {
-	for l.CurrentChar == ' ' || l.CurrentChar == '\t' || l.CurrentChar == '\r' {
+	for l.CurrentChar == ' ' || l.CurrentChar == '\t' {
 		l.AdvanceChar()
 	}
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -76,10 +76,11 @@ func TestAfterNewline(t *testing.T) {
 }
 
 func TestEmptySinglelineComment(t *testing.T) {
-	assertTokens(t, "//\nhello//\r\nthere//\rObi-Wan Kenobi", []token.Token{
+	assertTokens(t, "//\nhello//\r\nthere//\r!", []token.Token{
 		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []string{""}},
 		{Type: token.IDENT, Literal: "there", LeadingTrivia: []string{""}},
-		{Type: token.EOF, LeadingTrivia: []string{"\rObi-Wan Kenobi"}},
+		{Type: token.NOT, Literal: "!", LeadingTrivia: []string{""}},
+		{Type: token.EOF},
 	}, compareLeadingTrivia())
 }
 

--- a/lexer/parsers.go
+++ b/lexer/parsers.go
@@ -26,10 +26,12 @@ func (l *Lexer) parseMultilineComment() (string, token.TokenType) {
 func (l *Lexer) parseSinglelineComment() string {
 	sb := strings.Builder{}
 	for {
-		if l.CurrentChar == '\r' && l.PeekChar == '\n' {
-			// skip "\r\n" (Windows newline style)
+		if l.CurrentChar == '\r' {
 			l.AdvanceChar()
-			l.AdvanceChar()
+			if l.CurrentChar == '\n' {
+				// skip "\r\n" (Windows newline style)
+				l.AdvanceChar()
+			}
 			break
 		} else if l.CurrentChar == '\n' {
 			// skip "\n" (Unix newline style)

--- a/lexer/token_reader.go
+++ b/lexer/token_reader.go
@@ -89,6 +89,13 @@ func defaultTokenReader(l *Lexer) token.Token {
 		c := l.CurrentChar
 		l.AdvanceChar()
 		return token.Token{Type: token.RBRACE, Literal: string(c)}
+	case '\r':
+		l.AdvanceChar()
+		if l.CurrentChar == '\n' {
+			l.AdvanceChar()
+			return token.Token{Type: token.NEWLINE, Literal: ""}
+		}
+		return token.Token{Type: token.NEWLINE, Literal: ""}
 	case '\n':
 		l.AdvanceChar()
 		return token.Token{Type: token.NEWLINE, Literal: ""}


### PR DESCRIPTION
The `\r` rune is no longer considered a whitespace character. Now it is treated as a newline. Therefore, we have now three newline styles:

- `\n`: Unix Style
- `\r\n`: Windows Style
- `\r`: Unknown style (but complies with the JS specification)