### PR TITLE
refactor(lexer): treat CR as a newline

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -57,7 +57,7 @@ triviaLoop:
 		case token.NEWLINE, token.LCOMMENT:
 			afterNewline = true
 		case token.BCOMMENT:
-			afterNewline = afterNewline || strings.ContainsRune(tok.Literal, '\n')
+			afterNewline = afterNewline || strings.ContainsAny(tok.Literal, "\n\r")
 		default:
 			break triviaLoop
 		}
@@ -70,7 +70,7 @@ triviaLoop:
 }
 
 func (l *Lexer) skipWhitespaces() {
-	for l.CurrentChar == ' ' || l.CurrentChar == '\t' || l.CurrentChar == '\r' {
+	for l.CurrentChar == ' ' || l.CurrentChar == '\t' {
 		l.AdvanceChar()
 	}
 }

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -61,9 +62,13 @@ func TestAfterNewline(t *testing.T) {
 		input string
 	}{
 		{"newline before block comment", "hello\n/* block comment */world"},
-		{"block comment with newline", "hello/* block\ncomment */world"},
+		{"block comment with \n in the middle", "hello/* block\ncomment */world"},
+		{"block comment with \r in the middle", "hello/* block\rcomment */world"},
+		{"block comment with \r\n in the middle", "hello/* block\r\ncomment */world"},
 		{"single-line comment", "hello// comment\nworld"},
 		{"newline", "hello\nworld"},
+		{"newline", "hello\rworld"},
+		{"newline", "hello\r\nworld"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -76,10 +81,11 @@ func TestAfterNewline(t *testing.T) {
 }
 
 func TestEmptySinglelineComment(t *testing.T) {
-	assertTokens(t, "//\nhello//\r\nthere//\rObi-Wan Kenobi", []token.Token{
-		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []string{""}},
-		{Type: token.IDENT, Literal: "there", LeadingTrivia: []string{""}},
-		{Type: token.EOF, LeadingTrivia: []string{"\rObi-Wan Kenobi"}},
+	assertTokens(t, "//\nhello//\r\nthere//\r!", []token.Token{
+		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []string{"", ""}},
+		{Type: token.IDENT, Literal: "there", LeadingTrivia: []string{"", ""}},
+		{Type: token.NOT, Literal: "!", LeadingTrivia: []string{"", ""}},
+		{Type: token.EOF},
 	}, compareLeadingTrivia())
 }
 
@@ -105,8 +111,8 @@ func TestSinglelineComments(t *testing.T) {
 	
 	// Final comment`
 	assertTokens(t, input, []token.Token{
-		{Type: token.IDENT, Literal: "John", LeadingTrivia: []string{"", " First Name"}},
-		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: []string{"", "", " Last Name"}},
+		{Type: token.IDENT, Literal: "John", LeadingTrivia: []string{"", " First Name", ""}},
+		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: []string{"", "", " Last Name", ""}},
 		{Type: token.EOF, LeadingTrivia: []string{"", "", " Final comment"}},
 	}, compareLeadingTrivia())
 }
@@ -189,5 +195,20 @@ func TestReadString(t *testing.T) {
 			{Type: token.ILLEGAL, Literal: "\""},
 			{Type: token.EOF},
 		})
+	})
+	t.Run("illegal string with CR in the middle", func(t *testing.T) {
+		delimiters := []string{"'", "\""}
+		terminators := []string{"\n", "\r", "\r\n"}
+		for _, delimiter := range delimiters {
+			for _, terminator := range terminators {
+				input := fmt.Sprintf("%sHello%sWorld%s", delimiter, terminator, delimiter)
+				assertTokens(t, input, []token.Token{
+					{Type: token.ILLEGAL, Literal: delimiter + "Hello"},
+					{Type: token.IDENT, Literal: "World"},
+					{Type: token.ILLEGAL, Literal: delimiter},
+					{Type: token.EOF},
+				})
+			}
+		}
 	})
 }

--- a/lexer/parsers.go
+++ b/lexer/parsers.go
@@ -25,21 +25,8 @@ func (l *Lexer) parseMultilineComment() (string, token.TokenType) {
 
 func (l *Lexer) parseSinglelineComment() string {
 	sb := strings.Builder{}
-	for {
-		if l.CurrentChar == '\r' && l.PeekChar == '\n' {
-			// skip "\r\n" (Windows newline style)
-			l.AdvanceChar()
-			l.AdvanceChar()
-			break
-		} else if l.CurrentChar == '\n' {
-			// skip "\n" (Unix newline style)
-			l.AdvanceChar()
-			break
-		} else if l.CurrentChar == eof {
-			break
-		}
+	for ; l.CurrentChar != '\n' && l.CurrentChar != '\r' && l.CurrentChar != eof; l.AdvanceChar() {
 		sb.WriteRune(l.CurrentChar)
-		l.AdvanceChar()
 	}
 	return sb.String()
 }
@@ -71,7 +58,7 @@ func (l *Lexer) parseString(delimiter rune) (string, token.TokenType) {
 			sb.WriteRune(l.CurrentChar)
 			l.AdvanceChar()
 			break
-		} else if l.CurrentChar == eof || l.CurrentChar == '\n' {
+		} else if l.CurrentChar == eof || l.CurrentChar == '\n' || l.CurrentChar == '\r' {
 			return sb.String(), token.ILLEGAL
 		}
 		sb.WriteRune(l.CurrentChar)

--- a/lexer/token_reader.go
+++ b/lexer/token_reader.go
@@ -89,6 +89,12 @@ func defaultTokenReader(l *Lexer) token.Token {
 		c := l.CurrentChar
 		l.AdvanceChar()
 		return token.Token{Type: token.RBRACE, Literal: string(c)}
+	case '\r':
+		l.AdvanceChar()
+		if l.CurrentChar == '\n' {
+			l.AdvanceChar()
+		}
+		return token.Token{Type: token.NEWLINE, Literal: ""}
 	case '\n':
 		l.AdvanceChar()
 		return token.Token{Type: token.NEWLINE, Literal: ""}


### PR DESCRIPTION
The `\r` rune is no longer considered a whitespace character. Now it is treated as a newline. Therefore, we have now three newline styles:

- `\n`: Unix Style
- `\r\n`: Windows Style
- `\r`: Unknown style (but complies with the JS specification)