### PR TITLE
refactor(parser): decouple JS parsing logic into plugins

### DIFF
--- a/js/builder.go
+++ b/js/builder.go
@@ -1,0 +1,15 @@
+package js
+
+import (
+	"github.com/xjslang/xjs/lexer"
+	"github.com/xjslang/xjs/parser"
+)
+
+type Builder struct {
+	parser.Builder
+}
+
+func (b *Builder) Build(l *lexer.Lexer) *parser.Parser {
+	b.Install(LetPlugin)
+	return b.Builder.Build(l)
+}

--- a/js/let_plugin.go
+++ b/js/let_plugin.go
@@ -1,0 +1,48 @@
+package js
+
+import (
+	"github.com/xjslang/xjs/ast"
+	"github.com/xjslang/xjs/parser"
+	"github.com/xjslang/xjs/printer"
+	"github.com/xjslang/xjs/token"
+)
+
+type LetStatement struct {
+	Name  token.Token
+	Value ast.Expression
+}
+
+func (node *LetStatement) PrintTo(p *printer.Printer) {
+	p.PrintString("let ")
+	p.PrintString(node.Name.Literal)
+	p.PrintString(" = ")
+	node.Value.PrintTo(p)
+	p.PrintRune(';')
+}
+
+func LetPlugin(p *parser.Builder) {
+	p.UseStatementParser(func(p *parser.Parser, next func() (ast.Statement, error)) (ast.Statement, error) {
+		if p.CurrentToken.Type == token.LET {
+			stmt := &LetStatement{}
+			p.AdvanceToken() // consume let
+			ident := p.CurrentToken
+			if err := p.Expect(token.IDENT); err != nil {
+				return nil, err
+			}
+			stmt.Name = ident
+			if err := p.Expect(token.ASSIGN); err != nil {
+				return nil, err
+			}
+			val, err := p.ParseExpression()
+			if err != nil {
+				return nil, err
+			}
+			stmt.Value = val
+			if err := p.ExpectSemi(); err != nil {
+				return nil, err
+			}
+			return stmt, nil
+		}
+		return next()
+	})
+}

--- a/js/let_plugin_test.go
+++ b/js/let_plugin_test.go
@@ -1,0 +1,35 @@
+package js_test
+
+import (
+	"testing"
+
+	"github.com/xjslang/xjs/js"
+	"github.com/xjslang/xjs/lexer"
+	"github.com/xjslang/xjs/printer"
+)
+
+func TestXxx(t *testing.T) {
+	l := &lexer.Lexer{}
+	l.Init([]byte("let x = 100"))
+
+	b := js.Builder{}
+	p := b.Build(l)
+	pr, err := p.ParseProgram()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if n := len(pr.Statements); n != 1 {
+		t.Fatalf("Expected 1 statement, got %d", n)
+	}
+	stmt0, ok := pr.Statements[0].(*js.LetStatement)
+	if !ok {
+		t.Fatalf("Expected *js.LetStatement, got %T", pr.Statements[0])
+	}
+	prt := printer.New()
+	stmt0.PrintTo(prt)
+	expected := "let x = 100;"
+	if result := prt.String(); result != expected {
+		t.Fatalf("Expected %q, got %q", expected, result)
+	}
+}


### PR DESCRIPTION
Separate JavaScript-specific parsing logic from the core parser to make it more generic and reusable.

The parser now focuses on providing basic parsing infrastructure (AdvanceToken, Expect, ExpectSemi, etc.) while JavaScript syntax handling moves to dedicated plugins in the js/ package.

This architectural change allows the parser to be extended for different languages or dialects without coupling it to JavaScript semantics.

- Move let statement parsing to js.LetPlugin
- Prepare infrastructure for additional JS feature plugins