### PR TITLE
Refactor/scanner preserve line endings in tokens

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1,5 +1,5 @@
 package ast
 
 type Node interface {
-	Type() string
+	Kind() string
 }

--- a/ast/expressions.go
+++ b/ast/expressions.go
@@ -8,7 +8,7 @@ type InfixOperator struct {
 	RightValue Node
 }
 
-func (node *InfixOperator) Type() string {
+func (node *InfixOperator) Kind() string {
 	return "InfixOperator"
 }
 
@@ -16,7 +16,7 @@ type Integer struct {
 	Value string
 }
 
-func (node *Integer) Type() string {
+func (node *Integer) Kind() string {
 	return "Integer"
 }
 
@@ -24,7 +24,7 @@ type String struct {
 	Value string
 }
 
-func (node *String) Type() string {
+func (node *String) Kind() string {
 	return "String"
 }
 
@@ -32,7 +32,7 @@ type Boolean struct {
 	Value string
 }
 
-func (node *Boolean) Type() string {
+func (node *Boolean) Kind() string {
 	return "Boolean"
 }
 
@@ -40,7 +40,7 @@ type Ident struct {
 	Value string
 }
 
-func (node *Ident) Type() string {
+func (node *Ident) Kind() string {
 	return "Ident"
 }
 
@@ -48,6 +48,6 @@ type GroupedExpression struct {
 	Value Node
 }
 
-func (node *GroupedExpression) Type() string {
+func (node *GroupedExpression) Kind() string {
 	return "GroupedExpression"
 }

--- a/ast/statements.go
+++ b/ast/statements.go
@@ -7,7 +7,7 @@ type Let struct {
 	Value Node
 }
 
-func (node *Let) Type() string {
+func (node *Let) Kind() string {
 	return "let statement"
 }
 
@@ -15,7 +15,7 @@ type Block struct {
 	Statements []Node
 }
 
-func (node *Block) Type() string {
+func (node *Block) Kind() string {
 	return "block statement"
 }
 
@@ -24,6 +24,6 @@ type Function struct {
 	Body *Block
 }
 
-func (node *Function) Type() string {
+func (node *Function) Kind() string {
 	return "function declaration"
 }

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -79,7 +79,7 @@ func NodeString(node ast.Node) string {
 			indentLevel--
 		}()
 		indent := strings.Repeat("\t", indentLevel)
-		fmt.Print(node.Type())
+		fmt.Print(node.Kind())
 		switch v := node.(type) {
 		case *ast.Block:
 			for _, stmt := range v.Statements {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -35,15 +35,13 @@ type infixOperator struct {
 }
 
 type Parser struct {
-	scanner        *scanner.Scanner
-	CurrentToken   scanner.Token
-	PeekToken      scanner.Token
-	scopes         ScopeTracker
-	infixOperators map[scanner.Kind]infixOperator
-
+	CurrentToken    scanner.Token
+	PeekToken       scanner.Token
+	scanner         *scanner.Scanner
+	scopes          ScopeTracker
+	infixOperators  map[scanner.Kind]infixOperator
 	statementParser func(p *Parser) (ast.Node, error)
-
-	errors ErrorList
+	errors          ErrorList
 }
 
 func (p *Parser) Init(sc *scanner.Scanner) {

--- a/printer/middleware.go
+++ b/printer/middleware.go
@@ -35,6 +35,6 @@ func (p *Printer) defaultPrinter(node ast.Node) {
 	case *ast.Boolean:
 		p.PrintString(node.Value)
 	default:
-		p.PrintString("<" + node.Type() + ">")
+		p.PrintString("<" + node.Kind() + ">")
 	}
 }

--- a/scanner/consumers.go
+++ b/scanner/consumers.go
@@ -24,7 +24,23 @@ func (sc *Scanner) consumeBlockComment() (string, Kind) {
 
 func (sc *Scanner) consumeLineComment() string {
 	sb := strings.Builder{}
-	for sc.AdvanceChar(); sc.CurrentChar != '\n' && sc.CurrentChar != '\r' && sc.CurrentChar != eof; sc.AdvanceChar() {
+	for {
+		sc.AdvanceChar()
+		if sc.CurrentChar == '\n' {
+			sb.WriteRune(sc.CurrentChar)
+			sc.AdvanceChar()
+			break
+		} else if sc.CurrentChar == '\r' {
+			sb.WriteRune(sc.CurrentChar)
+			sc.AdvanceChar()
+			if sc.CurrentChar == '\n' {
+				sb.WriteRune(sc.CurrentChar)
+				sc.AdvanceChar()
+			}
+			break
+		} else if sc.CurrentChar == eof {
+			break
+		}
 		sb.WriteRune(sc.CurrentChar)
 	}
 	return sb.String()

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -109,11 +109,12 @@ func defaultScanner(sc *Scanner) Token {
 		sc.AdvanceChar()
 		if sc.CurrentChar == '\n' {
 			sc.AdvanceChar()
+			return Token{Type: NEWLINE, Literal: "\r\n"}
 		}
-		return Token{Type: NEWLINE, Literal: ""}
+		return Token{Type: NEWLINE, Literal: "\r"}
 	case '\n':
 		sc.AdvanceChar()
-		return Token{Type: NEWLINE, Literal: ""}
+		return Token{Type: NEWLINE, Literal: "\n"}
 	default:
 		if isLetter(sc.CurrentChar) {
 			lit := sc.consumeIdentifier()

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -88,8 +88,7 @@ triviaLoop:
 		switch tok.Type {
 		case NEWLINE:
 			afterNewline = true
-		case LINE_COMMENT:
-		case BLOCK_COMMENT:
+		case LINE_COMMENT, BLOCK_COMMENT:
 			afterNewline = afterNewline || strings.ContainsAny(tok.Literal, "\n\r")
 		default:
 			break triviaLoop

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -138,7 +138,7 @@ ipsum dolor */
 
 hello/* unfinished comment`
 	assertInputTokens(t, input, []scanner.Token{
-		{Type: scanner.IDENT, Literal: "hello", LeadingTrivia: []string{" lorem\nipsum dolor ", "", ""}},
+		{Type: scanner.IDENT, Literal: "hello", LeadingTrivia: []string{" lorem\nipsum dolor ", "\n", "\n"}},
 		{Type: scanner.ILLEGAL, Literal: " unfinished comment"},
 		{Type: scanner.EOF},
 	}, testutil.CompareLeadingTrivia())
@@ -154,17 +154,18 @@ func TestLineComments(t *testing.T) {
 	
 	// Final comment`
 	assertInputTokens(t, input, []scanner.Token{
-		{Type: scanner.IDENT, Literal: "John", LeadingTrivia: []string{"", " First Name", ""}},
-		{Type: scanner.IDENT, Literal: "Smith", LeadingTrivia: []string{"", "", " Last Name", ""}},
-		{Type: scanner.EOF, LeadingTrivia: []string{"", "", " Final comment"}},
+		{Type: scanner.IDENT, Literal: "John", LeadingTrivia: []string{"\n", " First Name\n"}},
+		{Type: scanner.IDENT, Literal: "Smith", LeadingTrivia: []string{"\n", "\n", " Last Name\n"}},
+		{Type: scanner.EOF, LeadingTrivia: []string{"\n", "\n", " Final comment"}},
 	}, testutil.CompareLeadingTrivia())
 }
 
 func TestEmptySinglelineComment(t *testing.T) {
-	assertInputTokens(t, "//\nhello//\r\nthere//\r!//", []scanner.Token{
-		{Type: scanner.IDENT, Literal: "hello", LeadingTrivia: []string{"", ""}},
-		{Type: scanner.IDENT, Literal: "there", LeadingTrivia: []string{"", ""}},
-		{Type: scanner.NOT, Literal: "!", LeadingTrivia: []string{"", ""}},
+	assertInputTokens(t, "//\nhello//\n\npeople//\r\nthere//\r!//", []scanner.Token{
+		{Type: scanner.IDENT, Literal: "hello", LeadingTrivia: []string{"\n"}},
+		{Type: scanner.IDENT, Literal: "people", LeadingTrivia: []string{"\n", "\n"}},
+		{Type: scanner.IDENT, Literal: "there", LeadingTrivia: []string{"\r\n"}},
+		{Type: scanner.NOT, Literal: "!", LeadingTrivia: []string{"\r"}},
 		{Type: scanner.EOF, Literal: "", LeadingTrivia: []string{""}},
 	}, testutil.CompareLeadingTrivia())
 }


### PR DESCRIPTION
- Store actual line ending characters ('\n', '\r', '\r\n') in NEWLINE
  token literals instead of empty strings. This preserves essential
  information for formatters that need to maintain original line endings.

- Include line endings in LINE_COMMENT tokens to reduce trivia count.
  Previously, line comments were followed by separate NEWLINE tokens,
  resulting in two trivia items. Now, the line ending is part of the
  comment token, reducing trivia overhead while maintaining all
  necessary information.