### PR TITLE
refactor(scanner): include line endings in tokens to preserve source fidelity

### DIFF
--- a/scanner/consumers.go
+++ b/scanner/consumers.go
@@ -24,7 +24,23 @@ func (sc *Scanner) consumeBlockComment() (string, Kind) {
 
 func (sc *Scanner) consumeLineComment() string {
 	sb := strings.Builder{}
-	for sc.AdvanceChar(); sc.CurrentChar != '\n' && sc.CurrentChar != '\r' && sc.CurrentChar != eof; sc.AdvanceChar() {
+	for {
+		sc.AdvanceChar()
+		if sc.CurrentChar == '\n' {
+			sb.WriteRune(sc.CurrentChar)
+			sc.AdvanceChar()
+			break
+		} else if sc.CurrentChar == '\r' {
+			sb.WriteRune(sc.CurrentChar)
+			sc.AdvanceChar()
+			if sc.CurrentChar == '\n' {
+				sb.WriteRune(sc.CurrentChar)
+				sc.AdvanceChar()
+			}
+			break
+		} else if sc.CurrentChar == eof {
+			break
+		}
 		sb.WriteRune(sc.CurrentChar)
 	}
 	return sb.String()

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -109,11 +109,12 @@ func defaultScanner(sc *Scanner) Token {
 		sc.AdvanceChar()
 		if sc.CurrentChar == '\n' {
 			sc.AdvanceChar()
+			return Token{Type: NEWLINE, Literal: "\r\n"}
 		}
-		return Token{Type: NEWLINE, Literal: ""}
+		return Token{Type: NEWLINE, Literal: "\r"}
 	case '\n':
 		sc.AdvanceChar()
-		return Token{Type: NEWLINE, Literal: ""}
+		return Token{Type: NEWLINE, Literal: "\n"}
 	default:
 		if isLetter(sc.CurrentChar) {
 			lit := sc.consumeIdentifier()

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -88,8 +88,7 @@ triviaLoop:
 		switch tok.Type {
 		case NEWLINE:
 			afterNewline = true
-		case LINE_COMMENT:
-		case BLOCK_COMMENT:
+		case LINE_COMMENT, BLOCK_COMMENT:
 			afterNewline = afterNewline || strings.ContainsAny(tok.Literal, "\n\r")
 		default:
 			break triviaLoop

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -133,13 +133,10 @@ func TestAfterNewline(t *testing.T) {
 }
 
 func TestBlockComments(t *testing.T) {
-	input := `/* lorem
-ipsum dolor */
-
-hello/* unfinished comment`
+	input := "/* lorem\nipsum dolor */\n\rhello\r\n/* unfinished comment"
 	assertInputTokens(t, input, []scanner.Token{
-		{Type: scanner.IDENT, Literal: "hello", LeadingTrivia: []string{" lorem\nipsum dolor ", "", ""}},
-		{Type: scanner.ILLEGAL, Literal: " unfinished comment"},
+		{Type: scanner.IDENT, Literal: "hello", LeadingTrivia: []string{" lorem\nipsum dolor ", "\n", "\r"}},
+		{Type: scanner.ILLEGAL, Literal: " unfinished comment", LeadingTrivia: []string{"\r\n"}},
 		{Type: scanner.EOF},
 	}, testutil.CompareLeadingTrivia())
 }
@@ -154,17 +151,18 @@ func TestLineComments(t *testing.T) {
 	
 	// Final comment`
 	assertInputTokens(t, input, []scanner.Token{
-		{Type: scanner.IDENT, Literal: "John", LeadingTrivia: []string{"", " First Name", ""}},
-		{Type: scanner.IDENT, Literal: "Smith", LeadingTrivia: []string{"", "", " Last Name", ""}},
-		{Type: scanner.EOF, LeadingTrivia: []string{"", "", " Final comment"}},
+		{Type: scanner.IDENT, Literal: "John", LeadingTrivia: []string{"\n", " First Name\n"}},
+		{Type: scanner.IDENT, Literal: "Smith", LeadingTrivia: []string{"\n", "\n", " Last Name\n"}},
+		{Type: scanner.EOF, LeadingTrivia: []string{"\n", "\n", " Final comment"}},
 	}, testutil.CompareLeadingTrivia())
 }
 
 func TestEmptySinglelineComment(t *testing.T) {
-	assertInputTokens(t, "//\nhello//\r\nthere//\r!//", []scanner.Token{
-		{Type: scanner.IDENT, Literal: "hello", LeadingTrivia: []string{"", ""}},
-		{Type: scanner.IDENT, Literal: "there", LeadingTrivia: []string{"", ""}},
-		{Type: scanner.NOT, Literal: "!", LeadingTrivia: []string{"", ""}},
+	assertInputTokens(t, "//\nhello//\n\npeople//\r\nthere//\r!//", []scanner.Token{
+		{Type: scanner.IDENT, Literal: "hello", LeadingTrivia: []string{"\n"}},
+		{Type: scanner.IDENT, Literal: "people", LeadingTrivia: []string{"\n", "\n"}},
+		{Type: scanner.IDENT, Literal: "there", LeadingTrivia: []string{"\r\n"}},
+		{Type: scanner.NOT, Literal: "!", LeadingTrivia: []string{"\r"}},
 		{Type: scanner.EOF, Literal: "", LeadingTrivia: []string{""}},
 	}, testutil.CompareLeadingTrivia())
 }


### PR DESCRIPTION
- Store actual line ending characters ('\n', '\r', '\r\n') in NEWLINE token literals instead of empty strings. This preserves essential information for formatters that need to maintain original line endings.

- Include line endings in LINE_COMMENT tokens to reduce trivia count. Previously, line comments were followed by separate NEWLINE tokens, resulting in two trivia items. Now, the line ending is part of the comment token, reducing trivia overhead while maintaining all necessary information.