### PR TITLE
refactor(parser): create ParseRemainingExpr func

### DIFF
--- a/parser/middleware.go
+++ b/parser/middleware.go
@@ -29,6 +29,22 @@ func (p *Parser) UseExprParser(parser func(p *Parser, next func() (ast.Node, err
 	}
 }
 
+func defaultOpParser(p *Parser, leftVal ast.Node) (node ast.Node, err error) {
+	op := p.CurrentToken
+	if op.Type == token.LPAREN {
+		return ParseCallExpr(p, leftVal)
+	}
+	nodeExpr := &ast.BinaryExpr{
+		LeftValue: leftVal,
+		Operator:  op,
+	}
+	if nodeExpr.RightValue, err = ParseRemainingExpr(p); err != nil {
+		return
+	}
+	node = nodeExpr
+	return
+}
+
 func defaultStmtParser(p *Parser) (ast.Node, error) {
 	switch p.CurrentToken.Type {
 	case token.LET:
@@ -40,90 +56,16 @@ func defaultStmtParser(p *Parser) (ast.Node, error) {
 	}
 }
 
-func defaultExprParser(p *Parser) (ast.Node, error) {
-	registered := func(typ token.Type) bool {
-		_, ok := p.infixOperators[typ]
-		return ok
+func defaultExprParser(p *Parser) (val ast.Node, err error) {
+	if val, err = p.parseValue(); err != nil {
+		return
 	}
-	precedence := func(typ token.Type) int {
-		if op, ok := p.infixOperators[typ]; ok {
-			return op.precedence
-		}
-		return -1
-	}
-	parseTerm := func() (ast.Node, token.Token, error) {
-		// parse val
-		val, err := p.parseValue()
-		if err != nil {
-			return nil, token.Token{}, err
-		}
-		// parse op
-		op := p.CurrentToken
-		return val, op, nil
-	}
-	parseInfixCall := func(val ast.Node) (node *ast.CallExpr, err error) {
-		node = &ast.CallExpr{
-			Function:  val,
-			Arguments: nil,
-		}
-		if node.LparenToken, err = p.Expect(token.LPAREN); err != nil {
-			return nil, err
-		}
-		if p.CurrentToken.Type != token.RPAREN {
-			for {
-				val, err := p.ParseExpr()
-				if err != nil {
-					return nil, err
-				}
-				node.Arguments = append(node.Arguments, val)
-				if p.CurrentToken.Type == token.RPAREN {
-					break
-				}
-				if _, err := p.Expect(token.COMMA); err != nil {
-					return nil, err
-				}
-			}
-		}
-		if node.RparenToken, err = p.Expect(token.RPAREN); err != nil {
-			return nil, err
-		}
-		return node, nil
-	}
-	var parseRightExp func(ast.Node, token.Token) (ast.Node, error)
-	parseRightExp = func(v0 ast.Node, op0 token.Token) (node ast.Node, err error) {
-		if op0.Type == token.LPAREN {
-			return parseInfixCall(v0)
-		}
-		for {
-			p.AdvanceToken()
-			v1, op1, err := parseTerm()
-			if err != nil {
-				return nil, err
-			}
-			if precedence(op0.Type) < precedence(op1.Type) {
-				v1, err = parseRightExp(v1, op1)
-				if err != nil {
-					return nil, err
-				}
-				op1 = p.CurrentToken
-			}
-			v0 = p.infixOperators[op0.Type].fn(op0, v0, v1)
-			if precedence(op0.Type) > precedence(op1.Type) {
-				return v0, nil
-			}
-			op0 = op1
-		}
-	}
-	v, op, err := parseTerm()
-	if err != nil {
-		return nil, err
-	}
-	for registered(op.Type) {
-		v, err = parseRightExp(v, op)
-		if err != nil {
-			return nil, err
+	op := p.CurrentToken
+	for p.isOperator(op) {
+		if val, err = defaultOpParser(p, val); err != nil {
+			return
 		}
 		op = p.CurrentToken
 	}
-	return v, nil
+	return
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -188,3 +188,16 @@ func (p *Parser) parseValue() (ast.Node, error) {
 	p.AddError(msg)
 	return nil, errors.New(msg)
 }
+
+func (p *Parser) isOperator(tok token.Token) bool {
+	_, ok := p.infixOperators[tok.Type]
+	return ok
+}
+
+func (p *Parser) precedence(tok token.Token) int {
+	op, ok := p.infixOperators[tok.Type]
+	if !ok {
+		return -1
+	}
+	return op.precedence
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -96,6 +96,16 @@ func TestExprs(t *testing.T) {
 		expected string
 	}{
 		{
+			input: "1 - 2 - 3",
+			expected: `BinaryExpr
+	LeftValue: BinaryExpr
+		LeftValue: BasicLit{Value: "1"}
+		Operator: "-"
+		RightValue: BasicLit{Value: "2"}
+	Operator: "-"
+	RightValue: BasicLit{Value: "3"}`,
+		},
+		{
 			input: "1 + 2 * (3 + 5) - 4",
 			expected: `BinaryExpr
 	LeftValue: BinaryExpr
@@ -113,10 +123,13 @@ func TestExprs(t *testing.T) {
 	RightValue: BasicLit{Value: "4"}`,
 		},
 		{
-			input: "foo() + 1",
+			input: "foo() * 2 + 1",
 			expected: `BinaryExpr
-	LeftValue: CallExpr
-		Function: Ident{Value: "foo"}
+	LeftValue: BinaryExpr
+		LeftValue: CallExpr
+			Function: Ident{Value: "foo"}
+		Operator: "*"
+		RightValue: BasicLit{Value: "2"}
 	Operator: "+"
 	RightValue: BasicLit{Value: "1"}`,
 		},
@@ -144,6 +157,23 @@ func TestExprs(t *testing.T) {
 					RightValue: BasicLit{Value: "3"}
 			Operator: "+"
 			RightValue: BasicLit{Value: "4"}`,
+		},
+		{
+			input: "1 + foo()",
+			expected: `BinaryExpr
+	LeftValue: BasicLit{Value: "1"}
+	Operator: "+"
+	RightValue: CallExpr
+		Function: Ident{Value: "foo"}`,
+		},
+		{
+			input: "1 + foo()()",
+			expected: `BinaryExpr
+	LeftValue: BasicLit{Value: "1"}
+	Operator: "+"
+	RightValue: CallExpr
+		Function: CallExpr
+			Function: Ident{Value: "foo"}`,
 		},
 	}
 	for i, test := range tests {

--- a/parser/parsing.go
+++ b/parser/parsing.go
@@ -75,6 +75,23 @@ func ParseExprStmt(p *Parser) (node *ast.ExprStmt, err error) {
 	return
 }
 
+func ParseRemainingExpr(p *Parser) (val ast.Node, err error) {
+	op := p.CurrentToken
+	p.AdvanceToken()
+	if val, err = p.parseValue(); err != nil {
+		return
+	}
+	for {
+		if !p.isOperator(p.CurrentToken) || p.precedence(op) >= p.precedence(p.CurrentToken) {
+			break
+		}
+		if val, err = defaultOpParser(p, val); err != nil {
+			return
+		}
+	}
+	return
+}
+
 func ParseParenExpr(p *Parser) (node *ast.ParenExpr, err error) {
 	node = &ast.ParenExpr{}
 	if node.LparenToken, err = p.Expect(token.LPAREN); err != nil {
@@ -130,5 +147,31 @@ func ParseFuncDecl(p *Parser) (node *ast.FuncDecl, err error) {
 		return
 	}
 	node.Body = body
+	return
+}
+
+func ParseCallExpr(p *Parser, leftVal ast.Node) (node *ast.CallExpr, err error) {
+	node = &ast.CallExpr{Function: leftVal}
+	if node.LparenToken, err = p.Expect(token.LPAREN); err != nil {
+		return
+	}
+	if p.CurrentToken.Type != token.RPAREN {
+		for {
+			val, err := p.ParseExpr()
+			if err != nil {
+				return nil, err
+			}
+			node.Arguments = append(node.Arguments, val)
+			if p.CurrentToken.Type == token.RPAREN {
+				break
+			}
+			if _, err := p.Expect(token.COMMA); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if node.RparenToken, err = p.Expect(token.RPAREN); err != nil {
+		return nil, err
+	}
 	return
 }


### PR DESCRIPTION
- Create `ParseRemainingExpr(*Parser)` to parse remaining expressions
- Simplify `defaultExprParser` for clarity