### PR TITLE
refactor(printer): separate formatting concerns into dedicated Formatter type

### DIFF
--- a/examples/djs/main.go
+++ b/examples/djs/main.go
@@ -66,17 +66,16 @@ func main() {
 	djsCompiler.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(ast.Node)) {
 		if node, ok := node.(*DeferStmt); ok {
 			pr.PrintTrivia(node.DeferToken.LeadingTrivia) // print previous comments and new lines
-			pr.EnsureLine()                               // ensure a new line is added before printing
-			pr.PrintIndentedString("{using _ = {[Symbol.dispose]() {")
-			pr.PrintNode(node.Stmt.Expr)
-			pr.PrintToken(node.Stmt.SemiToken)
-			pr.PrintIndentedString("}}}")
+			pr.LnPrint("{using _ = {[Symbol.dispose]() {")
+			pr.Print(node.Stmt.Expr)
+			pr.Print(node.Stmt.SemiToken)
+			pr.Print("}}}")
 			return
 		}
 		next(node)
 	})
 	djsCompiler.Init()
-	djsCompiler.PrintNode(node)
+	djsCompiler.Print(node)
 	fmt.Println(djsCompiler.String())
 
 	// create a formatter that can format `DeferStmt`
@@ -84,15 +83,15 @@ func main() {
 	djsFormatter.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(ast.Node)) {
 		if node, ok := node.(*DeferStmt); ok {
 			pr.EnsureLine() // ensure a new line is added before printing
-			pr.PrintToken(node.DeferToken)
+			pr.Print(node.DeferToken)
 			pr.EnsureSpace() // ensure a new space is added before printing
-			pr.PrintNode(node.Stmt.Expr)
-			pr.PrintToken(node.Stmt.SemiToken)
+			pr.Print(node.Stmt.Expr)
+			pr.Print(node.Stmt.SemiToken)
 			return
 		}
 		next(node)
 	})
 	djsFormatter.Init()
-	djsFormatter.PrintNode(node)
+	djsFormatter.Print(node)
 	fmt.Println(djsFormatter.String())
 }

--- a/examples/xjscli/main.go
+++ b/examples/xjscli/main.go
@@ -95,6 +95,6 @@ func main() {
 	}
 	pr := printer.Printer{}
 	pr.Init()
-	pr.PrintNode(program)
+	pr.Print(program)
 	fmt.Print(pr.String())
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -81,7 +81,7 @@ func Example_basic() {
 
 	pr := printer.Printer{}
 	pr.Init()
-	pr.PrintNode(result)
+	pr.Print(result)
 	fmt.Print(pr.String())
 	// Output:
 	// function hello() {

--- a/printer/internal/formatter/formatter.go
+++ b/printer/internal/formatter/formatter.go
@@ -1,0 +1,78 @@
+package formatter
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const EOL = rune(-1) // end of line
+
+type formatterConfig struct {
+	indent string
+}
+
+type FormatterOption func(*formatterConfig)
+
+func WithIndent(value string) FormatterOption {
+	return func(cfg *formatterConfig) {
+		cfg.indent = value
+	}
+}
+
+type Formatter struct {
+	doc         strings.Builder
+	indent      string
+	indentLevel int
+	LastChar    rune
+}
+
+func (f *Formatter) Init(opts ...FormatterOption) {
+	cfg := &formatterConfig{
+		indent: "  ",
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	f.doc.Reset()
+	f.indent = cfg.indent
+	f.indentLevel = 0
+	f.LastChar = EOL
+}
+
+func (f *Formatter) PrintString(s string) {
+	if len(s) == 0 {
+		return
+	}
+	r, _ := utf8.DecodeLastRuneInString(s)
+	f.LastChar = r
+	f.doc.WriteString(s)
+}
+
+func (f *Formatter) PrintRune(r rune) {
+	f.LastChar = r
+	f.doc.WriteRune(r)
+}
+
+func (f *Formatter) IncreaseIndent() {
+	f.indentLevel++
+}
+
+func (f *Formatter) DecreaseIndent() {
+	if f.indentLevel > 0 {
+		f.indentLevel--
+	}
+}
+
+func (f *Formatter) PrintIndent() {
+	for range f.indentLevel {
+		f.PrintString(f.indent)
+	}
+}
+
+func (f *Formatter) String() string {
+	return f.doc.String()
+}
+
+func (f *Formatter) Bytes() []byte {
+	return []byte(f.String())
+}

--- a/printer/internal/formatter/formatter_test.go
+++ b/printer/internal/formatter/formatter_test.go
@@ -1,0 +1,53 @@
+package formatter_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/xjslang/xjs/printer/internal/formatter"
+)
+
+func TestString(t *testing.T) {
+	tests := []struct {
+		name     string
+		indent   string
+		expected string
+	}{
+		{"with spaces", "    ", "block {\n    line 0;\n    line 1;\n    nested block {\n        line 0;\n        line 1;\n    }\n    line 2;\n}"},
+		{"with tabs", "\t", "block {\n\tline 0;\n\tline 1;\n\tnested block {\n\t\tline 0;\n\t\tline 1;\n\t}\n\tline 2;\n}"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := formatter.Formatter{}
+			f.Init(formatter.WithIndent(test.indent))
+			f.PrintString("block {\n")
+			f.IncreaseIndent()
+			for i := range 3 {
+				f.PrintIndent()
+				f.PrintString(fmt.Sprintf("line %d", i))
+				f.PrintRune(';')
+				if i == 1 {
+					f.PrintRune('\n')
+					f.PrintIndent()
+					f.PrintString("nested block {\n")
+					f.IncreaseIndent()
+					for j := range 2 {
+						f.PrintIndent()
+						f.PrintString(fmt.Sprintf("line %d", j))
+						f.PrintString(";\n")
+					}
+					f.DecreaseIndent()
+					f.PrintIndent()
+					f.PrintRune('}')
+				}
+				f.PrintRune('\n')
+			}
+			f.DecreaseIndent()
+			f.PrintIndent()
+			f.PrintRune('}')
+			if result := f.String(); result != test.expected {
+				t.Errorf("Expected %q, got %q", test.expected, result)
+			}
+		})
+	}
+}

--- a/printer/middleware.go
+++ b/printer/middleware.go
@@ -33,10 +33,10 @@ func defaultPrinter(p *Printer, node ast.Node) {
 	case *ast.BinaryExpr:
 		PrintBinaryExpr(p, node)
 	case *ast.Ident:
-		p.PrintToken(node.Value)
+		p.printToken(node.Value)
 	case *ast.BasicLit:
-		p.PrintToken(node.Value)
+		p.printToken(node.Value)
 	default:
-		p.PrintString("<" + node.Type() + ">")
+		p.printString("<" + node.Type() + ">")
 	}
 }

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -1,128 +1,83 @@
 package printer
 
 import (
-	"strings"
-	"unicode/utf8"
-
 	"github.com/xjslang/xjs/ast"
+	"github.com/xjslang/xjs/printer/internal/formatter"
 	"github.com/xjslang/xjs/token"
 )
 
-const eol = rune(-1) // end of line
+type PrinterOption = formatter.FormatterOption
 
-type printerConfig struct {
-	indent string
-}
-
-type printerOption func(*printerConfig)
-
-func WithIndent(value string) printerOption {
-	return func(cfg *printerConfig) {
-		cfg.indent = value
-	}
+func WithIndent(value string) PrinterOption {
+	return formatter.WithIndent(value)
 }
 
 type Printer struct {
-	doc         strings.Builder
-	indent      string
-	indentLevel int
-	printer     func(*Printer, ast.Node)
-	lastChar    rune
+	fmt         formatter.Formatter
 	ensureLine  bool
 	ensureSpace bool
+	printer     func(*Printer, ast.Node)
 }
 
-func (p *Printer) Init(opts ...printerOption) {
-	cfg := &printerConfig{
-		indent: "  ",
-	}
-	for _, opt := range opts {
-		opt(cfg)
-	}
+func (p *Printer) Init(opts ...PrinterOption) {
+	p.fmt.Init(opts...)
 	if p.printer == nil {
 		p.printer = defaultPrinter
 	}
-	p.indent = cfg.indent
-	p.lastChar = eol
-}
-
-func (p *Printer) PrintString(s string) {
-	if len(s) == 0 {
-		return
-	}
-	r, _ := utf8.DecodeLastRuneInString(s)
-	p.lastChar = r
-	p.doc.WriteString(s)
-}
-
-func (p *Printer) PrintRune(r rune) {
-	p.lastChar = r
-	p.doc.WriteRune(r)
 }
 
 func (p *Printer) IncreaseIndent() {
-	p.indentLevel++
+	p.fmt.IncreaseIndent()
 }
 
 func (p *Printer) DecreaseIndent() {
-	if p.indentLevel > 0 {
-		p.indentLevel--
-	}
+	p.fmt.DecreaseIndent()
 }
 
-func (p *Printer) PrintIndent() {
-	for range p.indentLevel {
-		p.doc.WriteString(p.indent)
-	}
-}
-
-func (p *Printer) PrintNode(node ast.Node) {
+func (p *Printer) printNode(node ast.Node) {
 	p.printer(p, node)
 }
 
 func (p *Printer) String() string {
-	return p.doc.String()
+	return p.fmt.String()
 }
 
 func (p *Printer) Bytes() []byte {
 	return []byte(p.String())
 }
 
-func (p *Printer) PrintIndentedString(s string) {
+func (p *Printer) printString(s string) {
 	if len(s) == 0 {
 		return
 	}
-	if p.ensureLine {
-		p.printLineIfNeeded()
-		p.ensureLine = false
-	}
-	if p.ensureSpace {
-		p.printSpaceIfNeeded()
-		p.ensureSpace = false
-	}
-	p.printIndentIfNeeded()
-	p.PrintString(s)
+	p.printSeparatorIfNeeded()
+	p.fmt.PrintString(s)
+}
+
+func (p *Printer) printRune(r rune) {
+	p.printSeparatorIfNeeded()
+	p.fmt.PrintRune(r)
 }
 
 func (p *Printer) PrintTrivia(trivia []token.Token) {
 	for _, tok := range trivia {
 		switch tok.Type {
 		case token.NEWLINE:
-			p.PrintRune('\n')
+			p.fmt.PrintRune('\n')
 		case token.LINE_COMMENT:
 			p.printSpaceIfNeeded()
 			p.printIndentIfNeeded()
-			p.PrintString("//" + tok.Literal)
+			p.fmt.PrintString("//" + tok.Literal)
 		case token.BLOCK_COMMENT:
 			p.printIndentIfNeeded()
-			p.PrintString("/*" + tok.Literal + "*/")
+			p.fmt.PrintString("/*" + tok.Literal + "*/")
 		}
 	}
 }
 
-func (p *Printer) PrintToken(tok token.Token) {
+func (p *Printer) printToken(tok token.Token) {
 	p.PrintTrivia(tok.LeadingTrivia)
-	p.PrintIndentedString(tok.Literal)
+	p.printString(tok.Literal)
 }
 
 func (p *Printer) EnsureLine() {
@@ -134,34 +89,48 @@ func (p *Printer) EnsureSpace() {
 }
 
 func (p *Printer) printLineIfNeeded() {
-	if !isNewLine(p.lastChar) {
-		p.PrintRune('\n')
+	if !isNewLine(p.fmt.LastChar) {
+		p.fmt.PrintRune('\n')
 	}
 }
 
 func (p *Printer) printSpaceIfNeeded() {
-	if !isWhitespace(p.lastChar) {
-		p.PrintRune(' ')
+	if !isWhitespace(p.fmt.LastChar) {
+		p.fmt.PrintRune(' ')
 	}
 }
 
 func (p *Printer) printIndentIfNeeded() {
-	if isNewLine(p.lastChar) {
-		p.PrintIndent()
+	if isNewLine(p.fmt.LastChar) {
+		p.fmt.PrintIndent()
 	}
+}
+
+func (p *Printer) printSeparatorIfNeeded() {
+	if p.ensureLine {
+		p.printLineIfNeeded()
+		p.ensureLine = false
+	}
+	if p.ensureSpace {
+		p.printSpaceIfNeeded()
+		p.ensureSpace = false
+	}
+	p.printIndentIfNeeded()
 }
 
 func (p *Printer) Print(args ...any) {
 	for _, arg := range args {
 		switch v := arg.(type) {
 		case string:
-			p.PrintIndentedString(v)
+			p.printString(v)
+		case rune:
+			p.printRune(v)
 		case ast.Node:
-			p.PrintNode(v)
+			p.printNode(v)
 		case token.Token:
-			p.PrintToken(v)
+			p.printToken(v)
 		default:
-			panic("Unsoported type")
+			panic("Unsupported type")
 		}
 	}
 }

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -25,6 +25,21 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+func TestInit(t *testing.T) {
+	t.Run("with custom indent", func(t *testing.T) {
+		pr := printer.Printer{}
+		pr.Init(printer.WithIndent("\t"))
+		pr.Print("begin:")
+		pr.IncreaseIndent()
+		pr.LnPrint("aaa")
+		pr.LnPrint("bbb")
+		pr.LnPrint("ccc")
+		pr.DecreaseIndent()
+		pr.LnPrint("end")
+		require.Equal(t, "begin:\n\taaa\n\tbbb\n\tccc\nend", pr.String())
+	})
+}
+
 func TestGoldenFiles(t *testing.T) {
 	if updateGoldenFiles {
 		t.Log("updating golden files")
@@ -195,58 +210,13 @@ func TestLastComment(t *testing.T) {
 	}
 }
 
-func TestString(t *testing.T) {
-	tests := []struct {
-		name     string
-		indent   string
-		expected string
-	}{
-		{"with spaces", "    ", "block {\n    line 0;\n    line 1;\n    nested block {\n        line 0;\n        line 1;\n    }\n    line 2;\n}"},
-		{"with tabs", "\t", "block {\n\tline 0;\n\tline 1;\n\tnested block {\n\t\tline 0;\n\t\tline 1;\n\t}\n\tline 2;\n}"},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			pr := printer.Printer{}
-			pr.Init(printer.WithIndent(test.indent))
-			pr.PrintString("block {\n")
-			pr.IncreaseIndent()
-			for i := range 3 {
-				pr.PrintIndent()
-				pr.PrintString(fmt.Sprintf("line %d", i))
-				pr.PrintRune(';')
-				if i == 1 {
-					pr.PrintRune('\n')
-					pr.PrintIndent()
-					pr.PrintString("nested block {\n")
-					pr.IncreaseIndent()
-					for j := range 2 {
-						pr.PrintIndent()
-						pr.PrintString(fmt.Sprintf("line %d", j))
-						pr.PrintString(";\n")
-					}
-					pr.DecreaseIndent()
-					pr.PrintIndent()
-					pr.PrintRune('}')
-				}
-				pr.PrintRune('\n')
-			}
-			pr.DecreaseIndent()
-			pr.PrintIndent()
-			pr.PrintRune('}')
-			if result := pr.String(); result != test.expected {
-				t.Errorf("Expected %q, got %q", test.expected, result)
-			}
-		})
-	}
-}
-
 func TestBytes(t *testing.T) {
 	input := "hello"
 	p := printer.Printer{}
 	p.Init()
-	p.PrintString(input)
+	p.Print(input)
 	b := p.Bytes()
-	// try to modify the underlaying data
+	// try to modify the underlying data
 	b[0] = 'H'
 	expected := "hello"
 	if got := p.String(); got != expected {
@@ -259,29 +229,47 @@ func TestEnsureLine(t *testing.T) {
 	pr.Init()
 	// calling EnsureLine at the beginning of a document does not print a new line
 	pr.EnsureLine()
-	pr.PrintIndentedString("aaa")
+	pr.Print("aaa")
 	// calling EnsureLine multiple times only prints a new line (it is idempotent)
 	for range 2 {
 		pr.EnsureLine()
 	}
-	pr.PrintIndentedString("bbb")
+	pr.Print("bbb")
 	// calling EnsureLine on a `\n` line does not print a new line
-	pr.PrintIndentedString("ccc\n")
+	pr.Print("ccc\n")
 	pr.EnsureLine()
-	pr.PrintIndentedString("ddd")
+	pr.Print("ddd")
 	// calling EnsureLine on a `\r` line does not print a new line
-	pr.PrintIndentedString("eee\r")
+	pr.Print("eee\r")
 	pr.EnsureLine()
-	pr.PrintIndentedString("fff")
+	pr.Print("fff")
 	// printing empty string does not reset `ensureLine`
 	pr.EnsureLine()
-	pr.PrintString("")
-	pr.PrintIndentedString("")
-	pr.PrintIndentedString("ggg")
+	pr.Print("")
+	pr.Print("")
+	pr.Print("ggg")
 	expected := "aaa\nbbbccc\ndddeee\rfff\nggg"
 	if got := pr.String(); got != expected {
 		t.Errorf("Expected %q, got %q", expected, got)
 	}
+
+	t.Run("printing empty string does not consume ensureLine", func(t *testing.T) {
+		pr := printer.Printer{}
+		pr.Init()
+		pr.Print("aaa")
+		pr.EnsureLine()
+		pr.Print("")
+		require.Equal(t, "aaa", pr.String())
+	})
+
+	t.Run("printing empty string does not consume ensureSpace", func(t *testing.T) {
+		pr := printer.Printer{}
+		pr.Init()
+		pr.Print("aaa")
+		pr.EnsureSpace()
+		pr.Print("")
+		require.Equal(t, "aaa", pr.String())
+	})
 }
 
 func TestEnsureSpace(t *testing.T) {
@@ -289,25 +277,25 @@ func TestEnsureSpace(t *testing.T) {
 	pr.Init()
 	// calling EnsureSpace at the beginning of a document does not print a new space
 	pr.EnsureSpace()
-	pr.PrintString("aaa")
+	pr.Print("aaa")
 	// calling EnsureSpace multiple times only prints a new space (it is idempotent)
 	for range 2 {
 		pr.EnsureSpace()
 	}
-	pr.PrintIndentedString("bbb")
+	pr.Print("bbb")
 	// calling EnsureSpace on a `\n` line does not print a new space
-	pr.PrintIndentedString("ccc\n")
+	pr.Print("ccc\n")
 	pr.EnsureSpace()
-	pr.PrintIndentedString("ddd")
+	pr.Print("ddd")
 	// calling EnsureSpace on a `\r` line does not print a new space
-	pr.PrintIndentedString("eee\r")
+	pr.Print("eee\r")
 	pr.EnsureSpace()
-	pr.PrintIndentedString("fff")
+	pr.Print("fff")
 	// printing empty string does not reset `ensureSpace`
 	pr.EnsureSpace()
-	pr.PrintString("")
-	pr.PrintIndentedString("")
-	pr.PrintIndentedString("ggg")
+	pr.Print("")
+	pr.Print("")
+	pr.Print("ggg")
 	expected := "aaa bbbccc\ndddeee\rfff ggg"
 	if got := pr.String(); got != expected {
 		t.Errorf("Expected %q, got %q", expected, got)
@@ -315,6 +303,14 @@ func TestEnsureSpace(t *testing.T) {
 }
 
 func TestPrint(t *testing.T) {
+	t.Run("append newlines and spaces before printing runes", func(t *testing.T) {
+		pr := printer.Printer{}
+		pr.Init()
+		pr.Print("aaa")
+		pr.LnPrint('b')
+		pr.SpPrint('c')
+		require.Equal(t, "aaa\nb c", pr.String())
+	})
 	t.Run("panic on unsupported types", func(t *testing.T) {
 		pr := printer.Printer{}
 		pr.Init()

--- a/printer/util.go
+++ b/printer/util.go
@@ -1,7 +1,9 @@
 package printer
 
+import "github.com/xjslang/xjs/printer/internal/formatter"
+
 func isNewLine(r rune) bool {
-	return r == eol || r == '\r' || r == '\n'
+	return r == formatter.EOL || r == '\r' || r == '\n'
 }
 
 func isWhitespace(r rune) bool {


### PR DESCRIPTION
Extract low-level formatting logic from Printer into a new internal Formatter type to simplify the Printer API and improve separation of concerns.

Changes:
- Create printer/internal/formatter package with Formatter type
- Move indentation management and string/rune printing to Formatter
- Reduce Printer's public API surface by making low-level methods private
- Delegate formatting operations to embedded Formatter instance
- Update examples and tests to use simplified API

The Printer now exposes a cleaner, higher-level API focused on printing AST nodes and tokens, while Formatter handles the low-level details of text output and indentation tracking.

Public API now consists of:
- Init()
- IncreaseIndent() / DecreaseIndent()
- EnsureLine() / EnsureSpace()
- Print() / LnPrint() / SpPrint() / PrintTrivia()
- String() / Bytes()