### PR TITLE
Refactor/parser rename functions for clarity

### DIFF
--- a/parser/middleware.go
+++ b/parser/middleware.go
@@ -5,7 +5,7 @@ import (
 	"github.com/xjslang/xjs/token"
 )
 
-func (p *Parser) UsePrefixExprParser(parser func(p *Parser, next func() (ast.Node, error)) (ast.Node, error)) {
+func (p *Parser) UsePrefixOpParser(parser func(p *Parser, next func() (ast.Node, error)) (ast.Node, error)) {
 	next := p.prefixExprParser
 	if next == nil {
 		next = defaultPrefixExprParser
@@ -17,7 +17,7 @@ func (p *Parser) UsePrefixExprParser(parser func(p *Parser, next func() (ast.Nod
 	}
 }
 
-func (p *Parser) UseInfixExprParser(parser func(p *Parser, leftVal ast.Node, next func(leftVal ast.Node) (ast.Node, error)) (ast.Node, error)) {
+func (p *Parser) UseInfixOpParser(parser func(p *Parser, leftVal ast.Node, next func(leftVal ast.Node) (ast.Node, error)) (ast.Node, error)) {
 	next := p.infixExprParser
 	if next == nil {
 		next = defaultInfixExprParser
@@ -76,7 +76,8 @@ func defaultInfixExprParser(p *Parser, leftVal ast.Node) (node ast.Node, err err
 		LeftValue: leftVal,
 		Operator:  op,
 	}
-	if nodeExpr.RightValue, err = ParseRightExpr(p); err != nil {
+	p.AdvanceToken()
+	if nodeExpr.RightValue, err = ParseRightValue(p, op.Type.Precedence()); err != nil {
 		return
 	}
 	node = nodeExpr
@@ -99,7 +100,7 @@ func defaultExprParser(p *Parser) (val ast.Node, err error) {
 		return
 	}
 	typ := p.CurrentToken.Type
-	for typ.IsBinaryOp() {
+	for typ.IsInfixOp() {
 		if val, err = p.infixExprParser(p, val); err != nil {
 			return
 		}

--- a/parser/middleware.go
+++ b/parser/middleware.go
@@ -54,6 +54,10 @@ func (p *Parser) UseExprParser(parser func(p *Parser, next func() (ast.Node, err
 }
 
 func defaultPrefixExprParser(p *Parser) (node ast.Node, err error) {
+	op := p.CurrentToken
+	if op.Type == token.LPAREN {
+		return ParseParenExpr(p)
+	}
 	nodeExpr := &ast.UnaryExpr{Operator: p.CurrentToken}
 	p.AdvanceToken()
 	if nodeExpr.Value, err = ParseValue(p); err != nil {

--- a/parser/middleware_test.go
+++ b/parser/middleware_test.go
@@ -43,8 +43,7 @@ func TestUseExprParser(t *testing.T) {
 		if p.CurrentToken.Type == orType {
 			orNode := &orExpr{Expr: node}
 			p.AdvanceToken() // consume "or"
-			orNode.FallbackStmt, err = p.ParseStmt()
-			if err != nil {
+			if orNode.FallbackStmt, err = p.ParseStmt(); err != nil {
 				return nil, err
 			}
 			node = orNode
@@ -71,36 +70,36 @@ func TestUseExprParser(t *testing.T) {
 	assert.Equal(t, "exit", funcName.Value.Literal)
 }
 
-type factorialExpr struct {
+type notBitwiseExpr struct {
 	Operator token.Token
 	Value    ast.Node
 }
 
-func (node *factorialExpr) Type() string {
-	return "factorialExpr"
+func (node *notBitwiseExpr) Type() string {
+	return "notBitwiseExpr"
 }
 
-func TestUsePrefixExprParser(t *testing.T) {
-	facType := token.RegisterUnaryOp("¡")
-	input := "1 + ¡7"
+func TestUsePrefixOpParser(t *testing.T) {
+	notBitwise := token.RegisterPrefixOp("~")
+	input := "1 + ~7"
 	s := &scanner.Scanner{}
 	s.UseScanner(func(sc *scanner.Scanner, next func() token.Token) token.Token {
-		if sc.CurrentChar == '¡' {
+		if sc.CurrentChar == '~' {
 			sc.AdvanceChar()
-			return token.Token{Type: facType, Literal: "¡"}
+			return token.Token{Type: notBitwise, Literal: "~"}
 		}
 		return next()
 	})
 	s.Init([]byte(input))
 	p := &parser.Parser{}
-	p.UsePrefixExprParser(func(p *parser.Parser, next func() (ast.Node, error)) (node ast.Node, err error) {
-		if p.CurrentToken.Type == facType {
-			factorialNode := &factorialExpr{Operator: p.CurrentToken}
-			p.AdvanceToken()
-			if factorialNode.Value, err = parser.ParseValue(p); err != nil {
+	p.UsePrefixOpParser(func(p *parser.Parser, next func() (ast.Node, error)) (node ast.Node, err error) {
+		if p.CurrentToken.Type == notBitwise {
+			nodeExpr := &notBitwiseExpr{Operator: p.CurrentToken}
+			p.AdvanceToken() // consume ~
+			if nodeExpr.Value, err = parser.ParseValue(p); err != nil {
 				return
 			}
-			node = factorialNode
+			node = nodeExpr
 			return
 		}
 		return next()
@@ -115,11 +114,11 @@ func TestUsePrefixExprParser(t *testing.T) {
 	require.IsType(t, &ast.BasicLit{}, binNode.LeftValue)
 	require.Equal(t, "1", binNode.LeftValue.(*ast.BasicLit).Value.Literal)
 	require.Equal(t, token.PLUS, binNode.Operator.Type)
-	require.IsType(t, &factorialExpr{}, binNode.RightValue)
-	facNode := binNode.RightValue.(*factorialExpr)
-	require.IsType(t, &ast.BasicLit{}, facNode.Value)
-	require.Equal(t, "7", facNode.Value.(*ast.BasicLit).Value.Literal)
-	require.Equal(t, facType, facNode.Operator.Type)
+	require.IsType(t, &notBitwiseExpr{}, binNode.RightValue)
+	rightNode := binNode.RightValue.(*notBitwiseExpr)
+	require.IsType(t, &ast.BasicLit{}, rightNode.Value)
+	require.Equal(t, "7", rightNode.Value.(*ast.BasicLit).Value.Literal)
+	require.Equal(t, notBitwise, rightNode.Operator.Type)
 }
 
 type powExpr struct {
@@ -132,8 +131,8 @@ func (node *powExpr) Type() string {
 	return "powExpr"
 }
 
-func TestUseInfixExprParser(t *testing.T) {
-	powType := token.RegisterBinaryOp("^", token.MULTIPLY.Precedence()+1)
+func TestUseInfixOpParser(t *testing.T) {
+	powType := token.RegisterInfixOp("^", token.MULTIPLY.Precedence()+1)
 	input := "1+5^2"
 	s := &scanner.Scanner{}
 	s.UseScanner(func(s *scanner.Scanner, next func() token.Token) token.Token {
@@ -145,10 +144,11 @@ func TestUseInfixExprParser(t *testing.T) {
 	})
 	s.Init([]byte(input))
 	p := &parser.Parser{}
-	p.UseInfixExprParser(func(p *parser.Parser, leftVal ast.Node, next func(ast.Node) (ast.Node, error)) (node ast.Node, err error) {
+	p.UseInfixOpParser(func(p *parser.Parser, leftVal ast.Node, next func(ast.Node) (ast.Node, error)) (node ast.Node, err error) {
 		if p.CurrentToken.Type == powType {
 			powNode := &powExpr{LeftValue: leftVal, Operator: p.CurrentToken}
-			if powNode.RightValue, err = parser.ParseRightExpr(p); err != nil {
+			p.AdvanceToken() // consume ^
+			if powNode.RightValue, err = parser.ParseRightValue(p, powType.Precedence()); err != nil {
 				return
 			}
 			node = powNode
@@ -174,4 +174,52 @@ func TestUseInfixExprParser(t *testing.T) {
 	require.Equal(t, powType, powNode.Operator.Type)
 	require.IsType(t, &ast.BasicLit{}, powNode.RightValue)
 	require.Equal(t, "2", powNode.RightValue.(*ast.BasicLit).Value.Literal)
+}
+
+type factorialExpr struct {
+	Operator token.Token
+	Value    ast.Node
+}
+
+func (node *factorialExpr) Type() string {
+	return "factorialExpr"
+}
+
+func TestUseInfixOpParser_postfix(t *testing.T) {
+	facTyp := token.RegisterInfixOp("!", -1)
+	input := "5! + 1"
+	s := &scanner.Scanner{}
+	s.UseScanner(func(s *scanner.Scanner, next func() token.Token) token.Token {
+		if s.CurrentChar == '!' {
+			s.AdvanceChar()
+			return token.Token{Type: facTyp, Literal: "!"}
+		}
+		return next()
+	})
+	s.Init([]byte(input))
+	p := &parser.Parser{}
+	p.UseInfixOpParser(func(p *parser.Parser, leftVal ast.Node, next func(leftVal ast.Node) (ast.Node, error)) (node ast.Node, err error) {
+		if p.CurrentToken.Type == facTyp {
+			leftVal = &factorialExpr{Operator: p.CurrentToken, Value: leftVal}
+			p.AdvanceToken() // consume !
+		}
+		return next(leftVal)
+	})
+	p.Init(s)
+	result, err := p.ParseExpr()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check the result
+	require.IsType(t, &ast.BinaryExpr{}, result)
+	binNode := result.(*ast.BinaryExpr)
+	require.IsType(t, &factorialExpr{}, binNode.LeftValue)
+	leftNode := binNode.LeftValue.(*factorialExpr)
+	require.IsType(t, &ast.BasicLit{}, leftNode.Value)
+	leftVal := leftNode.Value.(*ast.BasicLit)
+	require.Equal(t, "5", leftVal.Value.Literal)
+	require.Equal(t, facTyp, leftNode.Operator.Type)
+	require.IsType(t, &ast.BasicLit{}, binNode.RightValue)
+	rightVal := binNode.RightValue.(*ast.BasicLit)
+	require.Equal(t, "1", rightVal.Value.Literal)
 }

--- a/parser/parsing.go
+++ b/parser/parsing.go
@@ -99,8 +99,6 @@ func ParseValue(p *Parser) (ast.Node, error) {
 		return p.prefixExprParser(p)
 	}
 	switch typ {
-	case token.LPAREN:
-		return ParseParenExpr(p)
 	case token.NUMBER, token.STRING, token.BOOLEAN:
 		val := p.CurrentToken
 		p.AdvanceToken()

--- a/parser/parsing.go
+++ b/parser/parsing.go
@@ -75,15 +75,13 @@ func ParseExprStmt(p *Parser) (node *ast.ExprStmt, err error) {
 	return
 }
 
-func ParseRightExpr(p *Parser) (val ast.Node, err error) {
-	typ0 := p.CurrentToken.Type
-	p.AdvanceToken()
+func ParseRightValue(p *Parser, precedence int) (val ast.Node, err error) {
 	if val, err = ParseValue(p); err != nil {
 		return
 	}
 	for {
-		typ1 := p.CurrentToken.Type
-		if !typ1.IsBinaryOp() || typ0.Precedence() >= typ1.Precedence() {
+		typ := p.CurrentToken.Type
+		if !typ.IsInfixOp() || precedence >= typ.Precedence() {
 			break
 		}
 		if val, err = p.infixExprParser(p, val); err != nil {
@@ -95,7 +93,7 @@ func ParseRightExpr(p *Parser) (val ast.Node, err error) {
 
 func ParseValue(p *Parser) (ast.Node, error) {
 	typ := p.CurrentToken.Type
-	if typ.IsUnaryOp() {
+	if typ.IsPrefixOp() {
 		return p.prefixExprParser(p)
 	}
 	switch typ {

--- a/token/token.go
+++ b/token/token.go
@@ -140,7 +140,7 @@ func RegisterType(lit string) Type {
 	return typ
 }
 
-var binaryOps = map[Type]int{
+var infixOps = map[Type]int{
 	// || (lowest precedence for operators)
 	OR: 1,
 	// &&
@@ -164,51 +164,51 @@ var binaryOps = map[Type]int{
 	LPAREN: 7,
 }
 
-func (typ Type) IsBinaryOp() (ok bool) {
+func (typ Type) IsInfixOp() (ok bool) {
 	registerMu.RLock()
 	defer registerMu.RUnlock()
-	_, ok = binaryOps[typ]
+	_, ok = infixOps[typ]
 	return
 }
 
 func (typ Type) Precedence() int {
 	registerMu.RLock()
 	defer registerMu.RUnlock()
-	return binaryOps[typ]
+	return infixOps[typ]
 }
 
-func (typ Type) RegisterBinaryOp(precedence int) {
+func (typ Type) RegisterInfixOp(precedence int) {
 	registerMu.Lock()
 	defer registerMu.Unlock()
-	binaryOps[typ] = precedence
+	infixOps[typ] = precedence
 }
 
-func RegisterBinaryOp(lit string, precedence int) Type {
+func RegisterInfixOp(lit string, precedence int) Type {
 	typ := RegisterType(lit)
-	typ.RegisterBinaryOp(precedence)
+	typ.RegisterInfixOp(precedence)
 	return typ
 }
 
-var unaryOps = map[Type]bool{
+var prefixTypes = map[Type]bool{
 	NOT:    true,
 	LPAREN: true,
 }
 
-func (typ Type) IsUnaryOp() (ok bool) {
+func (typ Type) IsPrefixOp() (ok bool) {
 	registerMu.RLock()
 	defer registerMu.RUnlock()
-	_, ok = unaryOps[typ]
+	_, ok = prefixTypes[typ]
 	return
 }
 
-func (typ Type) RegisterUnaryOp() {
+func (typ Type) RegisterPrefixOp() {
 	registerMu.Lock()
 	defer registerMu.Unlock()
-	unaryOps[typ] = true
+	prefixTypes[typ] = true
 }
 
-func RegisterUnaryOp(lit string) Type {
+func RegisterPrefixOp(lit string) Type {
 	typ := RegisterType(lit)
-	typ.RegisterUnaryOp()
+	typ.RegisterPrefixOp()
 	return typ
 }

--- a/token/token.go
+++ b/token/token.go
@@ -190,7 +190,8 @@ func RegisterBinaryOp(lit string, precedence int) Type {
 }
 
 var unaryOps = map[Type]bool{
-	NOT: true,
+	NOT:    true,
+	LPAREN: true,
 }
 
 func (typ Type) IsUnaryOp() (ok bool) {


### PR DESCRIPTION
- Rename `UsePrefixExprParser` to `UsePrefixOpParser`
- Rename `ParseRightExpr` to `ParseRightValue`
- Change `ParseRightValue` signature to include `precedence` parameter
- `ParseRightValue` no longer consume the "infix operator"
- Rename `IsBinaryOp` to `IsInfixType`
- Rename `IsUnaryOp` to `IsPrefixType`
- Add `TestUseInfixOpParser_postfix` test
- Update `TestUseInfixOpParser`