### PR TITLE
refactor: move function artifacts to js/function.go

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -58,19 +58,6 @@ func (node *LetStmt) Type() string {
 	return "LetStmt"
 }
 
-type FuncDecl struct {
-	FunctionToken token.Token
-	LparenToken   token.Token
-	RparenToken   token.Token
-
-	Name token.Token
-	Body *Block
-}
-
-func (node *FuncDecl) Type() string {
-	return "FuncDecl"
-}
-
 type UnaryExpr struct {
 	Operator token.Token
 	Value    Node

--- a/examples/djs/main.go
+++ b/examples/djs/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/xjslang/xjs"
 	"github.com/xjslang/xjs/ast"
 	"github.com/xjslang/xjs/parser"
 	"github.com/xjslang/xjs/printer"
@@ -31,7 +32,7 @@ func main() {
 	}`
 
 	// create a scanner that can read "defer"
-	djsScanner := &scanner.Scanner{}
+	djsScanner := &xjs.Scanner{}
 	djsScanner.UseScanner(func(sc *scanner.Scanner, next func() token.Token) token.Token {
 		tok := next()
 		if tok.Type == token.IDENT && tok.Literal == "defer" {
@@ -42,7 +43,7 @@ func main() {
 	djsScanner.Init([]byte(input))
 
 	// create a parser that can parse "defer"
-	djsParser := &parser.Parser{}
+	djsParser := &xjs.Parser{}
 	djsParser.UseStmtParser(func(p *parser.Parser, next func() (ast.Node, error)) (node ast.Node, err error) {
 		if p.CurrentToken.Type == deferTyp {
 			deferStmt := &DeferStmt{DeferToken: p.CurrentToken}
@@ -56,13 +57,13 @@ func main() {
 		return next()
 	})
 	djsParser.Init(djsScanner)
-	node, err := parser.ParseProgram(djsParser)
+	node, err := djsParser.Parse()
 	if err != nil {
 		panic(err)
 	}
 
 	// create a compiler that can compile `DeferStmt`
-	djsCompiler := &printer.Printer{}
+	djsCompiler := &xjs.Printer{}
 	djsCompiler.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(ast.Node)) {
 		if node, ok := node.(*DeferStmt); ok {
 			pr.PrintTrivia(node.DeferToken.LeadingTrivia) // print previous comments and new lines
@@ -79,7 +80,7 @@ func main() {
 	fmt.Println(djsCompiler.String())
 
 	// create a formatter that can format `DeferStmt`
-	djsFormatter := &printer.Printer{}
+	djsFormatter := &xjs.Printer{}
 	djsFormatter.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(ast.Node)) {
 		if node, ok := node.(*DeferStmt); ok {
 			pr.EnsureLine() // ensure a new line is added before printing

--- a/examples/xjscli/main.go
+++ b/examples/xjscli/main.go
@@ -7,9 +7,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/xjslang/xjs"
 	"github.com/xjslang/xjs/parser"
-	"github.com/xjslang/xjs/printer"
-	"github.com/xjslang/xjs/scanner"
 )
 
 func usage() {
@@ -68,11 +67,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	sc := &scanner.Scanner{}
+	sc := &xjs.Scanner{}
 	sc.Init(data)
-	p := &parser.Parser{}
+	p := &xjs.Parser{}
 	p.Init(sc)
-	program, err := parser.ParseProgram(p)
+	program, err := p.Parse()
 
 	// prints errors
 	if checkFlag {
@@ -93,7 +92,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
-	pr := printer.Printer{}
+	pr := xjs.Printer{}
 	pr.Init()
 	pr.Print(program)
 	fmt.Print(pr.String())

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/xjslang/xjs/ast"
+	"github.com/xjslang/xjs/js"
 	"github.com/xjslang/xjs/parser"
 	"github.com/xjslang/xjs/scanner"
 	"github.com/xjslang/xjs/token"
@@ -88,6 +89,10 @@ func NodeString(node ast.Node) string {
 		switch v := node.(type) {
 		case *ast.Ident:
 			fmt.Fprintf(s, "{Value: %q}", v.Value.Literal)
+		case *ast.Program:
+			for _, stmt := range v.Stmts {
+				fmt.Fprintf(s, "\n%s%s", indent, print(stmt))
+			}
 		case *ast.Block:
 			for _, stmt := range v.Stmts {
 				fmt.Fprintf(s, "\n%s%s", indent, print(stmt))
@@ -97,7 +102,7 @@ func NodeString(node ast.Node) string {
 		case *ast.LetStmt:
 			fmt.Fprintf(s, "\n%sName: %s", indent, v.Name.Literal)
 			fmt.Fprintf(s, "\n%sValue: %s", indent, print(v.Value))
-		case *ast.FuncDecl:
+		case *js.Function:
 			fmt.Fprintf(s, "\n%sName: %s", indent, v.Name.Literal)
 			fmt.Fprintf(s, "\n%sBody: %s", indent, print(v.Body))
 		case *ast.ParenExpr:

--- a/js/function.go
+++ b/js/function.go
@@ -1,0 +1,50 @@
+package js
+
+import (
+	"github.com/xjslang/xjs/ast"
+	"github.com/xjslang/xjs/parser"
+	"github.com/xjslang/xjs/printer"
+	"github.com/xjslang/xjs/token"
+)
+
+var FUNCTION = token.RegisterType("function")
+
+type Function struct {
+	FunctionToken token.Token
+	LparenToken   token.Token
+	RparenToken   token.Token
+
+	Name token.Token
+	Body *ast.Block
+}
+
+func (node *Function) Type() string {
+	return "Function"
+}
+
+func ParseFunction(p *parser.Parser) (_ *Function, err error) {
+	node := &Function{}
+	if node.FunctionToken, err = p.Expect(FUNCTION); err != nil {
+		return
+	}
+	if node.Name, err = p.Expect(token.IDENT); err != nil {
+		return
+	}
+	if node.LparenToken, err = p.Expect(token.LPAREN); err != nil {
+		return
+	}
+	if node.RparenToken, err = p.Expect(token.RPAREN); err != nil {
+		return
+	}
+	if node.Body, err = parser.ParseBlock(p); err != nil {
+		return
+	}
+	return node, nil
+}
+
+func PrintFunction(p *printer.Printer, node *Function) {
+	p.LnPrint(node.FunctionToken)
+	p.SpPrint(node.Name)
+	p.Print(node.LparenToken, node.RparenToken)
+	p.SpPrint(node.Body)
+}

--- a/parser/middleware.go
+++ b/parser/middleware.go
@@ -88,8 +88,6 @@ func defaultStmtParser(p *Parser) (ast.Node, error) {
 	switch p.CurrentToken.Type {
 	case token.LET:
 		return ParseLetStmt(p)
-	case token.FUNCTION:
-		return ParseFuncDecl(p)
 	default:
 		return ParseExprStmt(p)
 	}

--- a/parser/middleware_test.go
+++ b/parser/middleware_test.go
@@ -84,7 +84,7 @@ func TestUsePrefixOpParser(t *testing.T) {
 	input := "1 + ~7"
 	s := &scanner.Scanner{}
 	s.UseScanner(func(sc *scanner.Scanner, next func() token.Token) token.Token {
-		if sc.CurrentChar == '~' {
+		if sc.CurrentChar() == '~' {
 			sc.AdvanceChar()
 			return token.Token{Type: notBitwise, Literal: "~"}
 		}
@@ -136,7 +136,7 @@ func TestUseInfixOpParser(t *testing.T) {
 	input := "1+5^2"
 	s := &scanner.Scanner{}
 	s.UseScanner(func(s *scanner.Scanner, next func() token.Token) token.Token {
-		if s.CurrentChar == '^' {
+		if s.CurrentChar() == '^' {
 			s.AdvanceChar()
 			return token.Token{Type: powType, Literal: "^"}
 		}
@@ -190,7 +190,7 @@ func TestUseInfixOpParser_postfix(t *testing.T) {
 	input := "5! + 1"
 	s := &scanner.Scanner{}
 	s.UseScanner(func(s *scanner.Scanner, next func() token.Token) token.Token {
-		if s.CurrentChar == '!' {
+		if s.CurrentChar() == '!' {
 			s.AdvanceChar()
 			return token.Token{Type: facTyp, Literal: "!"}
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,9 +6,12 @@ import (
 	"unicode/utf8"
 
 	"github.com/xjslang/xjs/ast"
-	"github.com/xjslang/xjs/scanner"
 	"github.com/xjslang/xjs/token"
 )
+
+type Scanner interface {
+	NextToken() token.Token
+}
 
 type Range struct {
 	Start token.Position `json:"start"`
@@ -33,7 +36,7 @@ func (list ErrorList) Error() string {
 type Parser struct {
 	CurrentToken     token.Token
 	PeekToken        token.Token
-	scanner          *scanner.Scanner
+	scanner          Scanner
 	scopes           ScopeTracker
 	stmtParser       func(p *Parser) (ast.Node, error)
 	exprParser       func(p *Parser) (ast.Node, error)
@@ -42,7 +45,7 @@ type Parser struct {
 	errors           ErrorList
 }
 
-func (p *Parser) Init(sc *scanner.Scanner) {
+func (p *Parser) Init(sc Scanner) {
 	p.scopes = make(ScopeTracker)
 	p.scanner = sc
 	if p.stmtParser == nil {
@@ -63,6 +66,10 @@ func (p *Parser) Init(sc *scanner.Scanner) {
 	// call twice to update CurrentToken and PeekToken
 	p.AdvanceToken()
 	p.AdvanceToken()
+}
+
+func (p *Parser) Parse() (*ast.Program, error) {
+	return ParseProgram(p)
 }
 
 func (p *Parser) ParseStmt() (ast.Node, error) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -2,14 +2,12 @@ package parser_test
 
 import (
 	"flag"
-	"fmt"
 	"os"
 	"strconv"
 	"testing"
 
 	"github.com/xjslang/xjs/internal/testutil"
 	"github.com/xjslang/xjs/parser"
-	"github.com/xjslang/xjs/printer"
 	"github.com/xjslang/xjs/scanner"
 )
 
@@ -19,26 +17,6 @@ func TestMain(m *testing.M) {
 	flag.BoolVar(&updateGoldenFiles, "update", false, "update golden files")
 	flag.Parse()
 	os.Exit(m.Run())
-}
-
-func Example_basic() {
-	result, err := testutil.Parse(`function hello() {
-	let x = 100
-	let y = 200
-}`)
-	if err != nil {
-		panic(err)
-	}
-
-	pr := printer.Printer{}
-	pr.Init()
-	pr.Print(result)
-	fmt.Print(pr.String())
-	// Output:
-	// function hello() {
-	//   let x = 100;
-	//   let y = 200;
-	// }
 }
 
 func TestExprs(t *testing.T) {

--- a/parser/parsing.go
+++ b/parser/parsing.go
@@ -147,28 +147,6 @@ func ParseLetStmt(p *Parser) (node *ast.LetStmt, err error) {
 	return
 }
 
-func ParseFuncDecl(p *Parser) (node *ast.FuncDecl, err error) {
-	node = &ast.FuncDecl{}
-	if node.FunctionToken, err = p.Expect(token.FUNCTION); err != nil {
-		return
-	}
-	if node.Name, err = p.Expect(token.IDENT); err != nil {
-		return
-	}
-	if node.LparenToken, err = p.Expect(token.LPAREN); err != nil {
-		return
-	}
-	if node.RparenToken, err = p.Expect(token.RPAREN); err != nil {
-		return
-	}
-	body, err := ParseBlock(p)
-	if err != nil {
-		return
-	}
-	node.Body = body
-	return
-}
-
 func ParseCallExpr(p *Parser, leftVal ast.Node) (node *ast.CallExpr, err error) {
 	node = &ast.CallExpr{Function: leftVal}
 	if node.LparenToken, err = p.Expect(token.LPAREN); err != nil {

--- a/parser/parsing_test.go
+++ b/parser/parsing_test.go
@@ -51,18 +51,6 @@ func TestMalformedExpr(t *testing.T) {
 			}
 		}
 	})
-	t.Run("function", func(t *testing.T) {
-		input := "() {}"
-		p := createParser(input)
-		_, err := parser.ParseFuncDecl(p)
-		if err == nil {
-			t.Fatal("Expected an error, got nil")
-		}
-		expected := "Expected function"
-		if got := err.Error(); got != expected {
-			t.Fatalf("Expected error to be %q, got %q", expected, got)
-		}
-	})
 	t.Run("grouped expression", func(t *testing.T) {
 		tests := []struct {
 			input       string
@@ -141,36 +129,6 @@ func TestKeysAreSaved(t *testing.T) {
 			testutil.CompareLeadingTrivia(),
 		)
 	})
-	t.Run("function", func(t *testing.T) {
-		input := `/* block comment before */
-	function foo
-	// comment 1
-	( // comment 2
-	) {}`
-		p := createParser(input)
-		result, err := parser.ParseFuncDecl(p)
-		if err != nil {
-			t.Fatal(err)
-		}
-		testutil.AssertTokens(
-			t,
-			[]token.Token{result.FunctionToken, result.LparenToken, result.RparenToken},
-			[]token.Token{
-				{Type: token.FUNCTION, Literal: "function", LeadingTrivia: []token.Token{
-					{Type: token.BLOCK_COMMENT, Literal: " block comment before "},
-					{Type: token.NEWLINE, Literal: "\n"},
-				}},
-				{Type: token.LPAREN, Literal: "(", LeadingTrivia: []token.Token{
-					{Type: token.NEWLINE, Literal: "\n"},
-					{Type: token.LINE_COMMENT, Literal: " comment 1\n"},
-				}},
-				{Type: token.RPAREN, Literal: ")", LeadingTrivia: []token.Token{
-					{Type: token.LINE_COMMENT, Literal: " comment 2\n"},
-				}},
-			},
-			testutil.CompareLeadingTrivia(),
-		)
-	})
 	t.Run("grouped expression", func(t *testing.T) {
 		input := `// comment before
 	(1 + 2// comment after
@@ -194,33 +152,6 @@ func TestKeysAreSaved(t *testing.T) {
 			testutil.CompareLeadingTrivia(),
 		)
 	})
-}
-
-func TestParseBlockErrorRecovery(t *testing.T) {
-	input := `function foo() {
-		let x = 100
-		let y 200 // syntax error, but keep parsing
-		let z = 300
-		let z = // syntax error, but keep parsing
-	}
-
-	let a = 'aaa'`
-	p := createParser(input)
-	_, err := parser.ParseFuncDecl(p)
-	if err == nil {
-		t.Fatalf("Expected an error, got nil")
-	}
-	expected := strings.Join([]string{
-		"Expected =",
-		"Expected value",
-	}, "\n")
-	if got := err.Error(); got != expected {
-		t.Fatalf("Expected %q, got %q", expected, got)
-	}
-	// keep parsing after `}`
-	if _, err := parser.ParseLetStmt(p); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestExprStmt(t *testing.T) {

--- a/printer/middleware.go
+++ b/printer/middleware.go
@@ -2,7 +2,7 @@ package printer
 
 import "github.com/xjslang/xjs/ast"
 
-func (p *Printer) UsePrinter(printer func(pr *Printer, node ast.Node, next func(node ast.Node))) {
+func (p *Printer) UsePrinter(printer func(p *Printer, node ast.Node, next func(node ast.Node))) {
 	print := p.printer
 	if p.printer == nil {
 		print = defaultPrinter
@@ -24,8 +24,6 @@ func defaultPrinter(p *Printer, node ast.Node) {
 		PrintExprStmt(p, node)
 	case *ast.LetStmt:
 		PrintLetStmt(p, node)
-	case *ast.FuncDecl:
-		PrintFuncDecl(p, node)
 	case *ast.CallExpr:
 		PrintCallExpr(p, node)
 	case *ast.ParenExpr:

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/pmezard/go-difflib/difflib"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/xjslang/xjs"
 	"github.com/xjslang/xjs/internal/testutil"
-	"github.com/xjslang/xjs/parser"
 	"github.com/xjslang/xjs/printer"
-	"github.com/xjslang/xjs/scanner"
 )
 
 var updateGoldenFiles bool
@@ -100,16 +99,16 @@ func TestGoldenFiles(t *testing.T) {
 		// parse the source file
 		source, err := os.ReadFile(file)
 		require.NoError(t, err)
-		s := &scanner.Scanner{}
+		s := &xjs.Scanner{}
 		s.Init(source)
-		p := &parser.Parser{}
+		p := &xjs.Parser{}
 		p.Init(s)
-		result, err := parser.ParseProgram(p)
+		result, err := p.Parse()
 		require.NoError(t, err)
 		// print the result
-		pr := &printer.Printer{}
+		pr := &xjs.Printer{}
 		pr.Init()
-		printer.PrintProgram(pr, result)
+		pr.Print(result)
 		// create or update golden file
 		got := pr.Bytes()
 		if updateGoldenFiles {
@@ -168,57 +167,6 @@ func TestPrintCallExpr(t *testing.T) {
 				t.Errorf("Expected:\n\n%s\n\nGot:\n\n%s", test.expected, got)
 			}
 		})
-	}
-}
-
-func TestCommentFormatting(t *testing.T) {
-	input := `//a
-		/*b*/ function//c
-						foo/*c*/(//d
-						)//e
-	{
-						//f
-						function boo(){
-							let a = 'aaa';/*g*/let b = 'bbb'/*h*/;
-						}
-		//c
-	}
-	let x = 100 //y
-	let y = (/*c*/100 //j
-	+//k
-	200)
-	log(x, y)/*l*/;
-	let z = 1
-	+ 2 // last comment`
-	expected := `//a
-/*b*/
-function //c
-foo/*c*/( //d
-) //e
-{
-  //f
-  function boo() {
-    let a = 'aaa';/*g*/
-    let b = 'bbb'/*h*/;
-  }
-  //c
-}
-let x = 100; //y
-let y = (/*c*/100 //j
-+ //k
-200);
-log(x, y)/*l*/;
-let z = 1
-+ 2; // last comment`
-	node, err := testutil.Parse(input)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pr := &printer.Printer{}
-	pr.Init()
-	printer.PrintProgram(pr, node)
-	if got := pr.String(); got != expected {
-		t.Errorf("Expected\n\n%s\n\ngot\n\n%s", expected, got)
 	}
 }
 

--- a/printer/printing.go
+++ b/printer/printing.go
@@ -33,13 +33,6 @@ func PrintLetStmt(p *Printer, node *ast.LetStmt) {
 	p.Print(node.SemiToken)
 }
 
-func PrintFuncDecl(p *Printer, node *ast.FuncDecl) {
-	p.LnPrint(node.FunctionToken)
-	p.SpPrint(node.Name)
-	p.Print(node.LparenToken, node.RparenToken)
-	p.SpPrint(node.Body)
-}
-
 func PrintCallExpr(p *Printer, node *ast.CallExpr) {
 	p.Print(node.Function, node.LparenToken)
 	for i, arg := range node.Arguments {

--- a/scanner/consumers.go
+++ b/scanner/consumers.go
@@ -10,15 +10,15 @@ func (sc *Scanner) consumeBlockComment() (string, token.Type) {
 	sb := strings.Builder{}
 	sc.AdvanceChar() // consume "*"
 	for {
-		if sc.CurrentChar == '*' && sc.PeekChar() == '/' {
+		if sc.currentChar == '*' && sc.PeekChar() == '/' {
 			// skip "*/"
 			sc.AdvanceChar()
 			sc.AdvanceChar()
 			break
-		} else if sc.CurrentChar == eof {
+		} else if sc.currentChar == eof {
 			return sb.String(), token.ILLEGAL
 		}
-		sb.WriteRune(sc.CurrentChar)
+		sb.WriteRune(sc.currentChar)
 		sc.AdvanceChar()
 	}
 	return sb.String(), token.BLOCK_COMMENT
@@ -28,57 +28,57 @@ func (sc *Scanner) consumeLineComment() string {
 	sb := strings.Builder{}
 	for {
 		sc.AdvanceChar()
-		if sc.CurrentChar == '\n' {
-			sb.WriteRune(sc.CurrentChar)
+		if sc.currentChar == '\n' {
+			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 			break
-		} else if sc.CurrentChar == '\r' {
-			sb.WriteRune(sc.CurrentChar)
+		} else if sc.currentChar == '\r' {
+			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
-			if sc.CurrentChar == '\n' {
-				sb.WriteRune(sc.CurrentChar)
+			if sc.currentChar == '\n' {
+				sb.WriteRune(sc.currentChar)
 				sc.AdvanceChar()
 			}
 			break
-		} else if sc.CurrentChar == eof {
+		} else if sc.currentChar == eof {
 			break
 		}
-		sb.WriteRune(sc.CurrentChar)
+		sb.WriteRune(sc.currentChar)
 	}
 	return sb.String()
 }
 
 func (sc *Scanner) consumeIdentifier() string {
 	sb := strings.Builder{}
-	sb.WriteRune(sc.CurrentChar)
-	for sc.AdvanceChar(); isLetter(sc.CurrentChar) || isDigit(sc.CurrentChar); sc.AdvanceChar() {
-		sb.WriteRune(sc.CurrentChar)
+	sb.WriteRune(sc.currentChar)
+	for sc.AdvanceChar(); isLetter(sc.currentChar) || isDigit(sc.currentChar); sc.AdvanceChar() {
+		sb.WriteRune(sc.currentChar)
 	}
 	return sb.String()
 }
 
 func (sc *Scanner) consumeNumber() string {
 	sb := strings.Builder{}
-	sb.WriteRune(sc.CurrentChar)
-	for sc.AdvanceChar(); isDigit(sc.CurrentChar); sc.AdvanceChar() {
-		sb.WriteRune(sc.CurrentChar)
+	sb.WriteRune(sc.currentChar)
+	for sc.AdvanceChar(); isDigit(sc.currentChar); sc.AdvanceChar() {
+		sb.WriteRune(sc.currentChar)
 	}
 	return sb.String()
 }
 
 func (sc *Scanner) consumeString(delimiter rune) (string, token.Type) {
 	sb := strings.Builder{}
-	sb.WriteRune(sc.CurrentChar)
+	sb.WriteRune(sc.currentChar)
 	for {
 		sc.AdvanceChar()
-		if sc.CurrentChar == delimiter {
-			sb.WriteRune(sc.CurrentChar)
+		if sc.currentChar == delimiter {
+			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 			break
-		} else if sc.CurrentChar == eof || sc.CurrentChar == '\n' || sc.CurrentChar == '\r' {
+		} else if sc.currentChar == eof || sc.currentChar == '\n' || sc.currentChar == '\r' {
 			return sb.String(), token.ILLEGAL
 		}
-		sb.WriteRune(sc.CurrentChar)
+		sb.WriteRune(sc.currentChar)
 	}
 	return sb.String(), token.STRING
 }

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -19,77 +19,77 @@ func (sc *Scanner) UseScanner(scanner func(sc *Scanner, next func() token.Token)
 }
 
 func defaultScanner(sc *Scanner) token.Token {
-	switch sc.CurrentChar {
+	switch sc.currentChar {
 	// operators
 	case '=':
-		c1 := sc.CurrentChar
+		c1 := sc.currentChar
 		sc.AdvanceChar()
-		if sc.CurrentChar == '=' {
-			c2 := sc.CurrentChar
+		if sc.currentChar == '=' {
+			c2 := sc.currentChar
 			sc.AdvanceChar()
 			return token.Token{Type: token.EQ, Literal: string([]rune{c1, c2})}
 		}
 		return token.Token{Type: token.ASSIGN, Literal: string(c1)}
 	case '!':
-		c1 := sc.CurrentChar
+		c1 := sc.currentChar
 		sc.AdvanceChar()
-		if sc.CurrentChar == '=' {
-			c2 := sc.CurrentChar
+		if sc.currentChar == '=' {
+			c2 := sc.currentChar
 			sc.AdvanceChar()
 			return token.Token{Type: token.NOT_EQ, Literal: string([]rune{c1, c2})}
 		}
 		return token.Token{Type: token.NOT, Literal: string(c1)}
 	case '<':
-		c1 := sc.CurrentChar
+		c1 := sc.currentChar
 		sc.AdvanceChar()
-		if sc.CurrentChar == '=' {
-			c2 := sc.CurrentChar
+		if sc.currentChar == '=' {
+			c2 := sc.currentChar
 			sc.AdvanceChar()
 			return token.Token{Type: token.LTE, Literal: string([]rune{c1, c2})}
 		}
 		return token.Token{Type: token.LT, Literal: string(c1)}
 	case '>':
-		c1 := sc.CurrentChar
+		c1 := sc.currentChar
 		sc.AdvanceChar()
-		if sc.CurrentChar == '=' {
-			c2 := sc.CurrentChar
+		if sc.currentChar == '=' {
+			c2 := sc.currentChar
 			sc.AdvanceChar()
 			return token.Token{Type: token.GTE, Literal: string([]rune{c1, c2})}
 		}
 		return token.Token{Type: token.GT, Literal: string(c1)}
 	case '|':
-		c1 := sc.CurrentChar
+		c1 := sc.currentChar
 		sc.AdvanceChar()
-		if sc.CurrentChar == '|' {
-			c2 := sc.CurrentChar
+		if sc.currentChar == '|' {
+			c2 := sc.currentChar
 			sc.AdvanceChar()
 			return token.Token{Type: token.OR, Literal: string([]rune{c1, c2})}
 		}
 		return token.Token{Type: token.UNKNOWN, Literal: string(c1)}
 	case '&':
-		c1 := sc.CurrentChar
+		c1 := sc.currentChar
 		sc.AdvanceChar()
-		if sc.CurrentChar == '&' {
-			c2 := sc.CurrentChar
+		if sc.currentChar == '&' {
+			c2 := sc.currentChar
 			sc.AdvanceChar()
 			return token.Token{Type: token.AND, Literal: string([]rune{c1, c2})}
 		}
 		return token.Token{Type: token.UNKNOWN, Literal: string(c1)}
 	// maths operators
 	case '+':
-		c1 := sc.CurrentChar
+		c1 := sc.currentChar
 		sc.AdvanceChar()
-		if sc.CurrentChar == '+' {
-			c2 := sc.CurrentChar
+		if sc.currentChar == '+' {
+			c2 := sc.currentChar
 			sc.AdvanceChar()
 			return token.Token{Type: token.INCREMENT, Literal: string([]rune{c1, c2})}
 		}
 		return token.Token{Type: token.PLUS, Literal: string(c1)}
 	case '-':
-		c1 := sc.CurrentChar
+		c1 := sc.currentChar
 		sc.AdvanceChar()
-		if sc.CurrentChar == '-' {
-			c2 := sc.CurrentChar
+		if sc.currentChar == '-' {
+			c2 := sc.currentChar
 			sc.AdvanceChar()
 			return token.Token{Type: token.DECREMENT, Literal: string([]rune{c1, c2})}
 		}
@@ -102,48 +102,48 @@ func defaultScanner(sc *Scanner) token.Token {
 		return token.Token{Type: token.MODULO, Literal: token.MODULO.String()}
 	// divide operator and comments
 	case '/':
-		c1 := sc.CurrentChar
+		c1 := sc.currentChar
 		sc.AdvanceChar()
-		if sc.CurrentChar == '/' {
+		if sc.currentChar == '/' {
 			comment := sc.consumeLineComment()
 			return token.Token{Type: token.LINE_COMMENT, Literal: comment}
 		}
-		if sc.CurrentChar == '*' {
+		if sc.currentChar == '*' {
 			comment, typ := sc.consumeBlockComment()
 			return token.Token{Type: typ, Literal: comment}
 		}
 		return token.Token{Type: token.DIVIDE, Literal: string(c1)}
 	case '\'', '"':
-		lit, typ := sc.consumeString(sc.CurrentChar)
+		lit, typ := sc.consumeString(sc.currentChar)
 		return token.Token{Type: typ, Literal: lit}
 	// delimiters
 	case ',':
-		c := sc.CurrentChar
+		c := sc.currentChar
 		sc.AdvanceChar()
 		return token.Token{Type: token.COMMA, Literal: string(c)}
 	case ';':
-		c := sc.CurrentChar
+		c := sc.currentChar
 		sc.AdvanceChar()
 		return token.Token{Type: token.SEMICOLON, Literal: string(c)}
 	case '(':
-		c := sc.CurrentChar
+		c := sc.currentChar
 		sc.AdvanceChar()
 		return token.Token{Type: token.LPAREN, Literal: string(c)}
 	case ')':
-		c := sc.CurrentChar
+		c := sc.currentChar
 		sc.AdvanceChar()
 		return token.Token{Type: token.RPAREN, Literal: string(c)}
 	case '{':
-		c := sc.CurrentChar
+		c := sc.currentChar
 		sc.AdvanceChar()
 		return token.Token{Type: token.LBRACE, Literal: string(c)}
 	case '}':
-		c := sc.CurrentChar
+		c := sc.currentChar
 		sc.AdvanceChar()
 		return token.Token{Type: token.RBRACE, Literal: string(c)}
 	case '\r':
 		sc.AdvanceChar()
-		if sc.CurrentChar == '\n' {
+		if sc.currentChar == '\n' {
 			sc.AdvanceChar()
 			return token.Token{Type: token.NEWLINE, Literal: "\r\n"}
 		}
@@ -152,23 +152,23 @@ func defaultScanner(sc *Scanner) token.Token {
 		sc.AdvanceChar()
 		return token.Token{Type: token.NEWLINE, Literal: "\n"}
 	default:
-		if isLetter(sc.CurrentChar) {
+		if isLetter(sc.currentChar) {
 			lit := sc.consumeIdentifier()
 			typ := lookup(lit)
 			return token.Token{Type: typ, Literal: lit}
-		} else if isDigit(sc.CurrentChar) {
+		} else if isDigit(sc.currentChar) {
 			lit := sc.consumeNumber()
 			return token.Token{Type: token.NUMBER, Literal: lit}
-		} else if sc.CurrentChar == utf8.RuneError {
-			c := sc.CurrentChar
+		} else if sc.currentChar == utf8.RuneError {
+			c := sc.currentChar
 			sc.AdvanceChar()
 			return token.Token{Type: token.ILLEGAL, Literal: string(c)}
-		} else if sc.CurrentChar == eof {
+		} else if sc.currentChar == eof {
 			return token.Token{Type: token.EOF, Literal: ""}
 		}
 	}
 
-	c := sc.CurrentChar
+	c := sc.currentChar
 	sc.AdvanceChar()
 	return token.Token{Type: token.UNKNOWN, Literal: string(c)}
 }
@@ -179,8 +179,6 @@ func lookup(lit string) token.Type {
 		return token.BOOLEAN
 	case "let":
 		return token.LET
-	case "function":
-		return token.FUNCTION
 	}
 	return token.IDENT
 }

--- a/scanner/middleware_test.go
+++ b/scanner/middleware_test.go
@@ -11,7 +11,7 @@ func TestUseScanner(t *testing.T) {
 	sc := &scanner.Scanner{}
 	powType := token.RegisterType("**")
 	sc.UseScanner(func(sc *scanner.Scanner, next func() token.Token) token.Token {
-		if sc.CurrentChar == '*' && sc.PeekChar() == '*' {
+		if sc.CurrentChar() == '*' && sc.PeekChar() == '*' {
 			// consume **
 			sc.AdvanceChar()
 			sc.AdvanceChar()

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -16,7 +16,7 @@ type Scanner struct {
 
 	scanner func(*Scanner) token.Token
 
-	CurrentChar rune
+	currentChar rune
 }
 
 func (sc *Scanner) Init(input []byte) {
@@ -32,10 +32,14 @@ func (sc *Scanner) Reset() {
 		sc.scanner = defaultScanner
 	}
 	sc.offset = 0
-	sc.CurrentChar = eof
+	sc.currentChar = eof
 	sc.line = 0
 	sc.column = -1
 	sc.AdvanceChar()
+}
+
+func (sc *Scanner) CurrentChar() rune {
+	return sc.currentChar
 }
 
 func (sc *Scanner) PeekChar() rune {
@@ -55,7 +59,7 @@ func (sc *Scanner) AdvanceChar() {
 		sc.line++
 		sc.column = -1
 	case '\n':
-		if sc.CurrentChar != '\r' {
+		if sc.currentChar != '\r' {
 			sc.line++
 			sc.column = -1
 		}
@@ -70,7 +74,7 @@ func (sc *Scanner) AdvanceChar() {
 	default:
 		sc.column++
 	}
-	sc.CurrentChar = r
+	sc.currentChar = r
 }
 
 func (sc *Scanner) NextToken() token.Token {
@@ -104,7 +108,7 @@ triviaLoop:
 }
 
 func (sc *Scanner) skipWhitespaces() {
-	for sc.CurrentChar == ' ' || sc.CurrentChar == '\t' {
+	for sc.currentChar == ' ' || sc.currentChar == '\t' {
 		sc.AdvanceChar()
 	}
 }

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -319,10 +319,9 @@ func TestReadString(t *testing.T) {
 }
 
 func TestKeywords(t *testing.T) {
-	input := "let function"
+	input := "let"
 	assertInputTokens(t, input, []token.Token{
 		{Type: token.LET, Literal: "let"},
-		{Type: token.FUNCTION, Literal: "function"},
 		{Type: token.EOF},
 	})
 }

--- a/token/token.go
+++ b/token/token.go
@@ -74,7 +74,6 @@ const (
 	BLOCK_COMMENT // /* ... */
 	// keywords
 	LET
-	FUNCTION
 )
 
 var tokenLiterals = map[Type]string{
@@ -120,8 +119,7 @@ var tokenLiterals = map[Type]string{
 	LINE_COMMENT:  "line comment",
 	BLOCK_COMMENT: "block comment",
 	// keywords
-	LET:      "let",
-	FUNCTION: "function",
+	LET: "let",
 }
 
 const initCustomType Type = 1000

--- a/xjs.go
+++ b/xjs.go
@@ -1,0 +1,69 @@
+package xjs
+
+import (
+	"github.com/xjslang/xjs/ast"
+	"github.com/xjslang/xjs/js"
+	"github.com/xjslang/xjs/parser"
+	"github.com/xjslang/xjs/printer"
+	"github.com/xjslang/xjs/scanner"
+	"github.com/xjslang/xjs/token"
+)
+
+type Scanner struct {
+	scanner.Scanner
+}
+
+func (s *Scanner) UseCoreScanners() {
+	s.UseScanner(func(sc *scanner.Scanner, next func() token.Token) token.Token {
+		tok := next()
+		if tok.Type == token.IDENT && tok.Literal == "function" {
+			tok.Type = js.FUNCTION
+		}
+		return tok
+	})
+}
+
+// TODO: https://github.com/xjslang/xjs/pull/141#discussion_r3321072513
+func (s *Scanner) Init(input []byte) {
+	s.UseCoreScanners()
+	s.Scanner.Init(input)
+}
+
+type Parser struct {
+	parser.Parser
+}
+
+func (p *Parser) UseCoreParsers() {
+	p.UseStmtParser(func(p *parser.Parser, next func() (ast.Node, error)) (ast.Node, error) {
+		if p.CurrentToken.Type == js.FUNCTION {
+			return js.ParseFunction(p)
+		}
+		return next()
+	})
+}
+
+// TODO: https://github.com/xjslang/xjs/pull/141#discussion_r3321072535
+func (p *Parser) Init(s parser.Scanner) {
+	p.UseCoreParsers()
+	p.Parser.Init(s)
+}
+
+type Printer struct {
+	printer.Printer
+}
+
+func (p *Printer) UseCorePrinters() {
+	p.UsePrinter(func(p *printer.Printer, node ast.Node, next func(node ast.Node)) {
+		if node, ok := node.(*js.Function); ok {
+			js.PrintFunction(p, node)
+			return
+		}
+		next(node)
+	})
+}
+
+// TODO: https://github.com/xjslang/xjs/pull/141#discussion_r3321072548
+func (p *Printer) Init(opts ...printer.Option) {
+	p.UseCorePrinters()
+	p.Printer.Init(opts...)
+}

--- a/xjs_test.go
+++ b/xjs_test.go
@@ -1,0 +1,92 @@
+package xjs_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/xjslang/xjs"
+	"github.com/xjslang/xjs/ast"
+	"github.com/xjslang/xjs/js"
+	"github.com/xjslang/xjs/parser"
+	"github.com/xjslang/xjs/printer"
+	"github.com/xjslang/xjs/token"
+)
+
+func Example_basic() {
+	input := `function hello() {
+	let x = 100
+	let y = 200
+}`
+	s := &xjs.Scanner{}
+	s.Init([]byte(input))
+	p := &xjs.Parser{}
+	p.Init(s)
+	result, err := p.Parse()
+	if err != nil {
+		panic(err)
+	}
+
+	pr := xjs.Printer{}
+	pr.Init()
+	pr.Print(result)
+	fmt.Print(pr.String())
+	// Output:
+	// function hello() {
+	//   let x = 100;
+	//   let y = 200;
+	// }
+}
+
+type iifeExpr struct {
+	LparenToken token.Token
+	RparenToken token.Token
+	Function    *js.Function
+}
+
+func (node *iifeExpr) Type() string {
+	return "iifeExpr"
+}
+
+func TestMiddlewares(t *testing.T) {
+	input := `(function foo() {
+		print('Hello, World!')
+	})()`
+	s := &xjs.Scanner{}
+	s.Init([]byte(input))
+	p := &xjs.Parser{}
+	// parse IIFE expressions
+	p.UsePrefixOpParser(func(p *parser.Parser, next func() (ast.Node, error)) (_ ast.Node, err error) {
+		if p.CurrentToken.Type == token.LPAREN && p.PeekToken.Type == js.FUNCTION {
+			node := &iifeExpr{LparenToken: p.CurrentToken}
+			p.AdvanceToken()
+			if node.Function, err = js.ParseFunction(p); err != nil {
+				return
+			}
+			if node.RparenToken, err = p.Expect(token.RPAREN); err != nil {
+				return
+			}
+			return node, nil
+		}
+		return next()
+	})
+	p.Init(s)
+	result, err := p.Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+	pr := &xjs.Printer{}
+	pr.UsePrinter(func(p *printer.Printer, node ast.Node, next func(node ast.Node)) {
+		if node, ok := node.(*iifeExpr); ok {
+			p.Print(node.LparenToken)
+			p.Print(node.Function)
+			p.Print(node.RparenToken)
+			return
+		}
+		next(node)
+	})
+	pr.Init(printer.WithIndent("\t"))
+	pr.Print(result)
+	expected := "(\nfunction foo() {\n\tprint('Hello, World!');\n})();"
+	require.Equal(t, expected, pr.String())
+}


### PR DESCRIPTION
and create `xjs.Scanner`, `xjs.Parser` and `xjs.Printer` for convenience.