### PR TITLE
refactor: ExpectSemi no longer depends on blockScope

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -140,11 +140,7 @@ func (p *Parser) ExpectSemi() (token.Token, error) {
 		p.AdvanceToken()
 		return tok, nil
 	}
-	if tok.Type == token.EOF || tok.AfterNewline {
-		tok = token.Token{Type: token.SEMICOLON, Literal: token.SEMICOLON.String(), Position: tok.Position}
-		return tok, nil
-	}
-	if p.InScope(blockScope) && tok.Type == token.RBRACE {
+	if tok.Type == token.EOF || tok.AfterNewline || tok.Type == token.RBRACE {
 		tok = token.Token{Type: token.SEMICOLON, Literal: token.SEMICOLON.String(), Position: tok.Position}
 		return tok, nil
 	}
@@ -160,8 +156,7 @@ func (p *Parser) AdvanceToStmtEnd() {
 			p.AdvanceToken()
 			break
 		}
-		if typ == token.EOF || p.CurrentToken.AfterNewline ||
-			p.InScope(blockScope) && typ == token.RBRACE {
+		if typ == token.EOF || p.CurrentToken.AfterNewline || typ == token.RBRACE {
 			break
 		}
 		p.AdvanceToken()

--- a/parser/parsing.go
+++ b/parser/parsing.go
@@ -7,8 +7,6 @@ import (
 	"github.com/xjslang/xjs/token"
 )
 
-var blockScope = RegisterScope()
-
 func ParseProgram(p *Parser) (node *ast.Program, err error) {
 	node = &ast.Program{}
 	for p.CurrentToken.Type != token.EOF {
@@ -33,8 +31,6 @@ func ParseProgram(p *Parser) (node *ast.Program, err error) {
 }
 
 func ParseBlock(p *Parser) (node *ast.Block, err error) {
-	p.EnterScope(blockScope)
-	defer p.ExitScope(blockScope)
 	node = &ast.Block{}
 	if node.LbraceToken, err = p.Expect(token.LBRACE); err != nil {
 		return


### PR DESCRIPTION
The behavior of `ExpectSemi` no longer depends on the `blockScope` variable and therefore does not depend on the `ParseBlock` function, which was responsible for managing that variable.

This move is a preliminary step to moving `ParseBlock` to the `js` folder.