### PR TITLE
refactor(printer): change `Parser.SpPrint` behaviour

### DIFF
--- a/js/binary_expr.go
+++ b/js/binary_expr.go
@@ -33,5 +33,6 @@ func ParseBinaryExpr(p *parser.Parser, leftVal ast.Node) (node ast.Node, err err
 
 func PrintBinaryExpr(p *printer.Printer, node *BinaryExpr) {
 	p.Print(node.LeftValue)
-	p.SpPrint(node.Operator, node.RightValue)
+	p.SpPrint(node.Operator)
+	p.SpPrint(node.RightValue)
 }

--- a/js/let_stmt.go
+++ b/js/let_stmt.go
@@ -45,6 +45,8 @@ func ParseLetStmt(p *parser.Parser) (_ *LetStmt, err error) {
 
 func PrintLetStmt(p *printer.Printer, node *LetStmt) {
 	p.LnPrint(node.LetToken)
-	p.SpPrint(node.Name, node.AssignToken, node.Value)
+	p.SpPrint(node.Name)
+	p.SpPrint(node.AssignToken)
+	p.SpPrint(node.Value)
 	p.Print(node.SemiToken)
 }

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -145,11 +145,9 @@ func (p *Printer) LnPrint(arg any) {
 	p.Print(arg)
 }
 
-func (p *Printer) SpPrint(args ...any) {
-	for _, arg := range args {
-		p.EnsureSpace()
-		p.Print(arg)
-	}
+func (p *Printer) SpPrint(arg any) {
+	p.EnsureSpace()
+	p.Print(arg)
 }
 
 func (p *Printer) PrintTrivia(trivia []token.Token) {

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -300,12 +300,11 @@ func TestSpacesTakePriorityOverLines(t *testing.T) {
 }
 
 func TestSpPrint(t *testing.T) {
-	t.Run("spaces are added in between", func(t *testing.T) {
-		pr := printer.Printer{}
-		pr.Init()
-		pr.SpPrint("aaa", "bbb", "ccc")
-		require.Equal(t, "aaa bbb ccc", pr.String())
-	})
+	pr := printer.Printer{}
+	pr.Init()
+	pr.SpPrint("aaa")
+	pr.SpPrint("bbb")
+	require.Equal(t, "aaa bbb", pr.String())
 }
 
 func TestWithComments(t *testing.T) {


### PR DESCRIPTION
This commit introduces a breaking API change.