### PR TITLE
refacor: declar ast.Stmt interface

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -9,7 +9,17 @@ type Expr interface {
 	exprNode()
 }
 
+type Stmt interface {
+	Node
+	stmtNode()
+}
+
 type ExprNode struct{}
 
 //nolint:unused
 func (ExprNode) exprNode() {}
+
+type StmtNode struct{}
+
+//nolint:unused
+func (StmtNode) stmtNode() {}

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -31,7 +31,7 @@ func (b *Builder) UseBinaryParser(parser func(p *parser.Parser, leftVal ast.Expr
 	b.parser.UseBinaryParser(parser)
 }
 
-func (b *Builder) UseStmtParser(parser func(p *parser.Parser, next func() (ast.Node, error)) (ast.Node, error)) {
+func (b *Builder) UseStmtParser(parser func(p *parser.Parser, next func() (ast.Stmt, error)) (ast.Stmt, error)) {
 	b.parser.UseStmtParser(parser)
 }
 

--- a/examples/djs/main.go
+++ b/examples/djs/main.go
@@ -15,10 +15,10 @@ import (
 
 var deferTyp = token.RegisterType("defer")
 
-// implements ast.Node
 type DeferStmt struct {
+	ast.StmtNode
 	DeferToken token.Token
-	Stmt       ast.Node
+	Stmt       ast.Stmt
 }
 
 func (node *DeferStmt) Type() string {
@@ -35,7 +35,7 @@ func djsPlugin(b *builder.Builder) {
 		return tok
 	})
 	// the parser can now parse "defer"
-	b.UseStmtParser(func(p *parser.Parser, next func() (ast.Node, error)) (node ast.Node, err error) {
+	b.UseStmtParser(func(p *parser.Parser, next func() (ast.Stmt, error)) (node ast.Stmt, err error) {
 		if p.CurrentToken.Type == deferTyp {
 			deferStmt := &DeferStmt{DeferToken: p.CurrentToken}
 			p.AdvanceToken() // consume "defer"

--- a/js/block_stmt.go
+++ b/js/block_stmt.go
@@ -10,10 +10,11 @@ import (
 )
 
 type BlockStmt struct {
+	ast.StmtNode
 	LbraceToken token.Token
 	RbraceToken token.Token
 
-	Stmts []ast.Node
+	Stmts []ast.Stmt
 }
 
 func (node *BlockStmt) Type() string {

--- a/js/call_expr.go
+++ b/js/call_expr.go
@@ -12,8 +12,8 @@ type CallExpr struct {
 	LparenToken token.Token
 	RparenToken token.Token
 
-	Function  ast.Node
-	Arguments []ast.Node
+	Function  ast.Expr
+	Arguments []ast.Expr
 }
 
 func (node *CallExpr) Type() string {
@@ -27,7 +27,7 @@ func ParseCallExpr(p *parser.Parser, leftVal ast.Expr) (_ *CallExpr, err error) 
 	}
 	if p.CurrentToken.Type != token.RPAREN {
 		for {
-			var val ast.Node
+			var val ast.Expr
 			if val, err = p.ParseExpr(); err != nil {
 				return
 			}

--- a/js/expr_stmt.go
+++ b/js/expr_stmt.go
@@ -8,9 +8,10 @@ import (
 )
 
 type ExprStmt struct {
+	ast.StmtNode
 	SemiToken token.Token
 
-	Expr ast.Node
+	Expr ast.Expr
 }
 
 func (node *ExprStmt) Type() string {

--- a/js/function_decl.go
+++ b/js/function_decl.go
@@ -1,6 +1,7 @@
 package js
 
 import (
+	"github.com/xjslang/xjs/ast"
 	"github.com/xjslang/xjs/parser"
 	"github.com/xjslang/xjs/printer"
 	"github.com/xjslang/xjs/token"
@@ -9,6 +10,7 @@ import (
 var FUNCTION = token.RegisterType("function")
 
 type FunctionDecl struct {
+	ast.StmtNode
 	FunctionToken token.Token
 	LparenToken   token.Token
 	RparenToken   token.Token

--- a/js/if_stmt.go
+++ b/js/if_stmt.go
@@ -13,14 +13,15 @@ var (
 )
 
 type IfStmt struct {
+	ast.StmtNode
 	IfToken     token.Token
 	LparenToken token.Token
 	RparenToken token.Token
 	ElseToken   token.Token
 
-	CondExpr ast.Node
-	ThenStmt ast.Node
-	ElseStmt ast.Node
+	CondExpr ast.Expr
+	ThenStmt ast.Stmt
+	ElseStmt ast.Stmt
 }
 
 func (node *IfStmt) Type() string {

--- a/js/let_stmt.go
+++ b/js/let_stmt.go
@@ -10,12 +10,13 @@ import (
 var LET = token.RegisterType("let")
 
 type LetStmt struct {
+	ast.StmtNode
 	LetToken    token.Token
 	AssignToken token.Token
 	SemiToken   token.Token
 
 	Name  token.Token
-	Value ast.Node
+	Value ast.Expr
 }
 
 func (node *LetStmt) Type() string {

--- a/js/paren_expr.go
+++ b/js/paren_expr.go
@@ -12,7 +12,7 @@ type ParenExpr struct {
 	LparenToken token.Token
 	RparenToken token.Token
 
-	Value ast.Node
+	Value ast.Expr
 }
 
 func (node *ParenExpr) Type() string {

--- a/js/program.go
+++ b/js/program.go
@@ -10,7 +10,7 @@ import (
 type Program struct {
 	EOFToken token.Token
 
-	Stmts []ast.Node
+	Stmts []ast.Stmt
 }
 
 func (node *Program) Type() string {

--- a/js/stmt.go
+++ b/js/stmt.go
@@ -6,7 +6,7 @@ import (
 	"github.com/xjslang/xjs/token"
 )
 
-func ParseStmt(p *parser.Parser) (_ ast.Node, err error) {
+func ParseStmt(p *parser.Parser) (_ ast.Stmt, err error) {
 	if p.CurrentToken.Type == token.LBRACE {
 		return ParseBlockStmt(p)
 	}

--- a/js/while_stmt.go
+++ b/js/while_stmt.go
@@ -10,12 +10,13 @@ import (
 var WHILE = token.RegisterType("while")
 
 type WhileStmt struct {
+	ast.StmtNode
 	WhileToken  token.Token
 	LparenToken token.Token
 	RparenToken token.Token
 
-	CondExpr ast.Node
-	ThenStmt ast.Node
+	CondExpr ast.Expr
+	ThenStmt ast.Stmt
 }
 
 func (node *WhileStmt) Type() string {

--- a/parser/middleware.go
+++ b/parser/middleware.go
@@ -22,10 +22,10 @@ func (p *Parser) UseBinaryParser(parser func(p *Parser, leftVal ast.Expr, next f
 	}
 }
 
-func (p *Parser) UseStmtParser(parser func(p *Parser, next func() (ast.Node, error)) (ast.Node, error)) {
+func (p *Parser) UseStmtParser(parser func(p *Parser, next func() (ast.Stmt, error)) (ast.Stmt, error)) {
 	next := p.stmtParser
-	p.stmtParser = func(p *Parser) (ast.Node, error) {
-		return parser(p, func() (ast.Node, error) {
+	p.stmtParser = func(p *Parser) (ast.Stmt, error) {
+		return parser(p, func() (ast.Stmt, error) {
 			return next(p)
 		})
 	}

--- a/parser/middleware_test.go
+++ b/parser/middleware_test.go
@@ -16,7 +16,7 @@ import (
 type orExpr struct {
 	ast.ExprNode
 	Value        ast.Expr
-	FallbackStmt ast.Node
+	FallbackStmt ast.Stmt
 }
 
 func (node *orExpr) Type() string {
@@ -74,7 +74,7 @@ func TestUseExprParser(t *testing.T) {
 type notBitwiseExpr struct {
 	ast.ExprNode
 	Operator token.Token
-	Value    ast.Node
+	Value    ast.Expr
 }
 
 func (node *notBitwiseExpr) Type() string {
@@ -123,9 +123,9 @@ func TestUseUnaryParser(t *testing.T) {
 
 type powExpr struct {
 	ast.ExprNode
-	LeftValue  ast.Node
+	LeftValue  ast.Expr
 	Operator   token.Token
-	RightValue ast.Node
+	RightValue ast.Expr
 }
 
 func (node *powExpr) Type() string {
@@ -178,7 +178,7 @@ func TestUseBinaryParser(t *testing.T) {
 type factorialExpr struct {
 	ast.ExprNode
 	Operator token.Token
-	Value    ast.Node
+	Value    ast.Expr
 }
 
 func (node *factorialExpr) Type() string {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -38,7 +38,7 @@ type Parser struct {
 	PeekToken        token.Token
 	scanner          Scanner
 	scopes           ScopeTracker
-	stmtParser       func(p *Parser) (ast.Node, error)
+	stmtParser       func(p *Parser) (ast.Stmt, error)
 	exprParser       func(p *Parser) (ast.Expr, error)
 	binaryExprParser func(p *Parser, leftVal ast.Expr) (ast.Expr, error)
 	unaryExprParser  func(p *Parser) (ast.Expr, error)
@@ -53,7 +53,7 @@ func (p *Parser) Init(sc Scanner) {
 	p.scopes = make(ScopeTracker)
 	p.scanner = sc
 	if p.stmtParser == nil {
-		p.stmtParser = func(p *Parser) (ast.Node, error) {
+		p.stmtParser = func(p *Parser) (ast.Stmt, error) {
 			return nil, errors.New("unknown statement")
 		}
 	}
@@ -80,7 +80,7 @@ func (p *Parser) Init(sc Scanner) {
 	p.AdvanceToken()
 }
 
-func (p *Parser) ParseStmt() (ast.Node, error) {
+func (p *Parser) ParseStmt() (ast.Stmt, error) {
 	return p.stmtParser(p)
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -19,6 +19,7 @@ import (
 var updateGoldenFiles bool
 
 type MyCustomStmt struct {
+	ast.StmtNode
 	LparenToken token.Token
 	RparenToken token.Token
 	Message     token.Token
@@ -34,7 +35,7 @@ func ExampleParser_Init() {
 	p := &parser.Parser{}
 
 	// Declare "middlewares" BEFORE calling Init
-	p.UseStmtParser(func(p *parser.Parser, next func() (ast.Node, error)) (_ ast.Node, err error) {
+	p.UseStmtParser(func(p *parser.Parser, next func() (ast.Stmt, error)) (_ ast.Stmt, err error) {
 		if p.CurrentToken.Type == token.IDENT && p.CurrentToken.Literal == "print" {
 			p.AdvanceToken()
 			node := &MyCustomStmt{}

--- a/xjs.go
+++ b/xjs.go
@@ -80,7 +80,7 @@ func jsPlugin(b *builder.Builder) {
 		}
 		return
 	})
-	b.UseStmtParser(func(p *parser.Parser, next func() (ast.Node, error)) (ast.Node, error) {
+	b.UseStmtParser(func(p *parser.Parser, next func() (ast.Stmt, error)) (ast.Stmt, error) {
 		switch p.CurrentToken.Type {
 		case js.FUNCTION:
 			return js.ParseFunctionDecl(p)


### PR DESCRIPTION
- Declared `ast.Stmt` interface
- Declared `ast.StmtNode` struct wich implements `ast.Stmt`
- Replaced `ast.Node` with `ast.Stmt` where appropiate
- Replaced `ast.Node` with `ast.Expr` where appropiate