### PR TITLE
Refactor/ast remove type from node interfaz

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -1,7 +1,7 @@
 package ast
 
 type Node interface {
-	Type() string
+	node()
 }
 
 type Expr interface {
@@ -16,10 +16,10 @@ type Stmt interface {
 
 type ExprNode struct{}
 
-//nolint:unused
+func (ExprNode) node()     {}
 func (ExprNode) exprNode() {}
 
 type StmtNode struct{}
 
-//nolint:unused
+func (StmtNode) node()     {}
 func (StmtNode) stmtNode() {}

--- a/examples/djs/main.go
+++ b/examples/djs/main.go
@@ -21,10 +21,6 @@ type DeferStmt struct {
 	Stmt       ast.Stmt
 }
 
-func (node *DeferStmt) Type() string {
-	return "DeferStmt"
-}
-
 func djsPlugin(b *builder.Builder) {
 	// the scanner that can read "defer"
 	b.UseScanner(func(sc *scanner.Scanner, next func() token.Token) token.Token {

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -83,7 +83,7 @@ func NodeString(node ast.Node) string {
 			indentLevel--
 		}()
 		indent := strings.Repeat("\t", indentLevel)
-		fmt.Fprint(s, node.Type())
+		fmt.Fprintf(s, "%T", node)
 		switch v := node.(type) {
 		case *js.Ident:
 			fmt.Fprintf(s, "{Name: %q}", v.Name.Literal)

--- a/js/binary_expr.go
+++ b/js/binary_expr.go
@@ -14,10 +14,6 @@ type BinaryExpr struct {
 	Right ast.Expr
 }
 
-func (node *BinaryExpr) Type() string {
-	return "BinaryExpr"
-}
-
 func ParseBinaryExpr(p *parser.Parser, left ast.Expr) (node ast.Expr, err error) {
 	op := p.CurrentToken
 	nodeExpr := &BinaryExpr{

--- a/js/block_stmt.go
+++ b/js/block_stmt.go
@@ -17,10 +17,6 @@ type BlockStmt struct {
 	Stmts []ast.Stmt
 }
 
-func (node *BlockStmt) Type() string {
-	return "Block"
-}
-
 func ParseBlockStmt(p *parser.Parser) (_ *BlockStmt, err error) {
 	node := &BlockStmt{}
 	if node.LbraceToken, err = p.Expect(token.LBRACE); err != nil {

--- a/js/call_expr.go
+++ b/js/call_expr.go
@@ -16,10 +16,6 @@ type CallExpr struct {
 	Args   []ast.Expr
 }
 
-func (node *CallExpr) Type() string {
-	return "CallExpr"
-}
-
 func ParseCallExpr(p *parser.Parser, left ast.Expr) (_ *CallExpr, err error) {
 	node := &CallExpr{Callee: left}
 	if node.LparenToken, err = p.Expect(token.LPAREN); err != nil {

--- a/js/expr_stmt.go
+++ b/js/expr_stmt.go
@@ -8,13 +8,9 @@ import (
 )
 
 type ExprStmt struct {
-	ast.Expr
 	ast.StmtNode
 	SemiToken token.Token
-}
-
-func (node *ExprStmt) Type() string {
-	return "Stmt"
+	Expr      ast.Expr
 }
 
 func ParseExprStmt(p *parser.Parser) (_ *ExprStmt, err error) {

--- a/js/function_decl.go
+++ b/js/function_decl.go
@@ -19,10 +19,6 @@ type FunctionDecl struct {
 	Body *BlockStmt
 }
 
-func (node *FunctionDecl) Type() string {
-	return "FunctionDecl"
-}
-
 func ParseFunctionDecl(p *parser.Parser) (_ *FunctionDecl, err error) {
 	node := &FunctionDecl{}
 	if node.FunctionToken, err = p.Expect(FUNCTION); err != nil {

--- a/js/if_stmt.go
+++ b/js/if_stmt.go
@@ -24,10 +24,6 @@ type IfStmt struct {
 	Else ast.Stmt
 }
 
-func (node *IfStmt) Type() string {
-	return "IfStmt"
-}
-
 func ParseIfStmt(p *parser.Parser) (_ *IfStmt, err error) {
 	node := &IfStmt{}
 	// if

--- a/js/js.go
+++ b/js/js.go
@@ -10,15 +10,7 @@ type Ident struct {
 	Name token.Token
 }
 
-func (node *Ident) Type() string {
-	return "Ident"
-}
-
 type Literal struct {
 	ast.ExprNode
 	Value token.Token
-}
-
-func (node *Literal) Type() string {
-	return "Literal"
 }

--- a/js/let_stmt.go
+++ b/js/let_stmt.go
@@ -19,10 +19,6 @@ type LetStmt struct {
 	Value ast.Expr
 }
 
-func (node *LetStmt) Type() string {
-	return "LetStmt"
-}
-
 func ParseLetStmt(p *parser.Parser) (_ *LetStmt, err error) {
 	node := &LetStmt{}
 	if node.LetToken, err = p.Expect(LET); err != nil {

--- a/js/paren_expr.go
+++ b/js/paren_expr.go
@@ -15,10 +15,6 @@ type ParenExpr struct {
 	Value ast.Expr
 }
 
-func (node *ParenExpr) Type() string {
-	return "ParenExpr"
-}
-
 func ParseParenExpr(p *parser.Parser) (_ *ParenExpr, err error) {
 	node := &ParenExpr{}
 	if node.LparenToken, err = p.Expect(token.LPAREN); err != nil {

--- a/js/program.go
+++ b/js/program.go
@@ -8,13 +8,10 @@ import (
 )
 
 type Program struct {
+	ast.StmtNode
 	EOFToken token.Token
 
 	Stmts []ast.Stmt
-}
-
-func (node *Program) Type() string {
-	return "Program"
 }
 
 func ParseProgram(p *parser.Parser) (_ *Program, err error) {

--- a/js/unary_expr.go
+++ b/js/unary_expr.go
@@ -13,10 +13,6 @@ type UnaryExpr struct {
 	Value ast.Expr
 }
 
-func (node *UnaryExpr) Type() string {
-	return "UnaryExpr"
-}
-
 func ParseUnaryExpr(p *parser.Parser) (node ast.Expr, err error) {
 	nodeExpr := &UnaryExpr{Op: p.CurrentToken}
 	p.AdvanceToken()

--- a/js/while_stmt.go
+++ b/js/while_stmt.go
@@ -19,10 +19,6 @@ type WhileStmt struct {
 	Then ast.Stmt
 }
 
-func (node *WhileStmt) Type() string {
-	return "WhileStmt"
-}
-
 func ParseWhileStmt(p *parser.Parser) (_ *WhileStmt, err error) {
 	node := &WhileStmt{}
 	// while

--- a/parser/middleware_test.go
+++ b/parser/middleware_test.go
@@ -19,10 +19,6 @@ type orExpr struct {
 	FallbackStmt ast.Stmt
 }
 
-func (node *orExpr) Type() string {
-	return "orExpr"
-}
-
 func TestUseExprParser(t *testing.T) {
 	orType := token.RegisterType("or")
 	input := "let x = openDb() or exit('failed opening db')"
@@ -77,10 +73,6 @@ type notBitwiseExpr struct {
 	Value    ast.Expr
 }
 
-func (node *notBitwiseExpr) Type() string {
-	return "notBitwiseExpr"
-}
-
 func TestUseUnaryParser(t *testing.T) {
 	notBitwise := token.RegisterUnaryOp("~")
 	input := "1 + ~7"
@@ -126,10 +118,6 @@ type powExpr struct {
 	LeftValue  ast.Expr
 	Operator   token.Token
 	RightValue ast.Expr
-}
-
-func (node *powExpr) Type() string {
-	return "powExpr"
 }
 
 func TestUseBinaryParser(t *testing.T) {
@@ -179,10 +167,6 @@ type factorialExpr struct {
 	ast.ExprNode
 	Operator token.Token
 	Value    ast.Expr
-}
-
-func (node *factorialExpr) Type() string {
-	return "factorialExpr"
 }
 
 func TestUseBinaryParser_postfix(t *testing.T) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -25,10 +25,6 @@ type MyCustomStmt struct {
 	Message     token.Token
 }
 
-func (node *MyCustomStmt) Type() string {
-	return "MyCustomStmt"
-}
-
 func ExampleParser_Init() {
 	s := &scanner.Scanner{}
 	s.Init([]byte("print('Hello, World!')"))
@@ -77,83 +73,83 @@ func TestExprs(t *testing.T) {
 	}{
 		{
 			input: "1 - 2 - 3",
-			expected: `BinaryExpr
-	Left: BinaryExpr
-		Left: Literal{Value: "1"}
+			expected: `*js.BinaryExpr
+	Left: *js.BinaryExpr
+		Left: *js.Literal{Value: "1"}
 		Op: "-"
-		Right: Literal{Value: "2"}
+		Right: *js.Literal{Value: "2"}
 	Op: "-"
-	Right: Literal{Value: "3"}`,
+	Right: *js.Literal{Value: "3"}`,
 		},
 		{
 			input: "1 + 2 * (3 + 5) - 4",
-			expected: `BinaryExpr
-	Left: BinaryExpr
-		Left: Literal{Value: "1"}
+			expected: `*js.BinaryExpr
+	Left: *js.BinaryExpr
+		Left: *js.Literal{Value: "1"}
 		Op: "+"
-		Right: BinaryExpr
-			Left: Literal{Value: "2"}
+		Right: *js.BinaryExpr
+			Left: *js.Literal{Value: "2"}
 			Op: "*"
-			Right: ParenExpr
-				Value: BinaryExpr
-					Left: Literal{Value: "3"}
+			Right: *js.ParenExpr
+				Value: *js.BinaryExpr
+					Left: *js.Literal{Value: "3"}
 					Op: "+"
-					Right: Literal{Value: "5"}
+					Right: *js.Literal{Value: "5"}
 	Op: "-"
-	Right: Literal{Value: "4"}`,
+	Right: *js.Literal{Value: "4"}`,
 		},
 		{
 			input: "foo() * 2 + 1",
-			expected: `BinaryExpr
-	Left: BinaryExpr
-		Left: CallExpr
-			Callee: Ident{Name: "foo"}
+			expected: `*js.BinaryExpr
+	Left: *js.BinaryExpr
+		Left: *js.CallExpr
+			Callee: *js.Ident{Name: "foo"}
 		Op: "*"
-		Right: Literal{Value: "2"}
+		Right: *js.Literal{Value: "2"}
 	Op: "+"
-	Right: Literal{Value: "1"}`,
+	Right: *js.Literal{Value: "1"}`,
 		},
 		{
 			input: "foo(1, 2, 3)",
-			expected: `CallExpr
-	Callee: Ident{Name: "foo"}
-	Args[0]: Literal{Value: "1"}
-	Args[1]: Literal{Value: "2"}
-	Args[2]: Literal{Value: "3"}`,
+			expected: `*js.CallExpr
+	Callee: *js.Ident{Name: "foo"}
+	Args[0]: *js.Literal{Value: "1"}
+	Args[1]: *js.Literal{Value: "2"}
+	Args[2]: *js.Literal{Value: "3"}`,
 		},
 		{
 			input: "2 * (pow(2, 1 + 3) + 4)",
-			expected: `BinaryExpr
-	Left: Literal{Value: "2"}
+			expected: `*js.BinaryExpr
+	Left: *js.Literal{Value: "2"}
 	Op: "*"
-	Right: ParenExpr
-		Value: BinaryExpr
-			Left: CallExpr
-				Callee: Ident{Name: "pow"}
-				Args[0]: Literal{Value: "2"}
-				Args[1]: BinaryExpr
-					Left: Literal{Value: "1"}
+	Right: *js.ParenExpr
+		Value: *js.BinaryExpr
+			Left: *js.CallExpr
+				Callee: *js.Ident{Name: "pow"}
+				Args[0]: *js.Literal{Value: "2"}
+				Args[1]: *js.BinaryExpr
+					Left: *js.Literal{Value: "1"}
 					Op: "+"
-					Right: Literal{Value: "3"}
+					Right: *js.Literal{Value: "3"}
 			Op: "+"
-			Right: Literal{Value: "4"}`,
+			Right: *js.Literal{Value: "4"}`,
 		},
 		{
 			input: "1 + foo()",
-			expected: `BinaryExpr
-	Left: Literal{Value: "1"}
+			expected: `*js.BinaryExpr
+	Left: *js.Literal{Value: "1"}
 	Op: "+"
-	Right: CallExpr
-		Callee: Ident{Name: "foo"}`,
+	Right: *js.CallExpr
+		Callee: *js.Ident{Name: "foo"}`,
 		},
 		{
 			input: "1 + foo()()",
-			expected: `BinaryExpr
-	Left: Literal{Value: "1"}
+			expected: `*js.BinaryExpr
+	Left: *js.Literal{Value: "1"}
 	Op: "+"
-	Right: CallExpr
-		Callee: CallExpr
-			Callee: Ident{Name: "foo"}`,
+	Right: *js.CallExpr
+		Callee: *js.CallExpr
+			Callee: *js.Ident{Name: "foo"}`,
 		},
 	}
 	for i, test := range tests {

--- a/parser/parsing_test.go
+++ b/parser/parsing_test.go
@@ -115,24 +115,24 @@ func TestStmt(t *testing.T) {
 	}{
 		{
 			input: "log()",
-			expected: `Stmt
-	Expr: CallExpr
-		Callee: Ident{Name: "log"}`,
+			expected: `*js.ExprStmt
+	Expr: *js.CallExpr
+		Callee: *js.Ident{Name: "log"}`,
 		},
 		{
 			input: "log(1)",
-			expected: `Stmt
-	Expr: CallExpr
-		Callee: Ident{Name: "log"}
-		Args[0]: Literal{Value: "1"}`,
+			expected: `*js.ExprStmt
+	Expr: *js.CallExpr
+		Callee: *js.Ident{Name: "log"}
+		Args[0]: *js.Literal{Value: "1"}`,
 		},
 		{
 			input: "log(1, 2)",
-			expected: `Stmt
-	Expr: CallExpr
-		Callee: Ident{Name: "log"}
-		Args[0]: Literal{Value: "1"}
-		Args[1]: Literal{Value: "2"}`,
+			expected: `*js.ExprStmt
+	Expr: *js.CallExpr
+		Callee: *js.Ident{Name: "log"}
+		Args[0]: *js.Literal{Value: "1"}
+		Args[1]: *js.Literal{Value: "2"}`,
 		},
 	}
 	for i, test := range tests {

--- a/printer/middleware.go
+++ b/printer/middleware.go
@@ -17,5 +17,5 @@ func (p *Printer) UsePrinter(printer func(p *Printer, node ast.Node, next func(n
 }
 
 func defaultPrinter(p *Printer, node ast.Node) {
-	p.printString("<" + node.Type() + ">")
+	p.printString("<unknown>")
 }

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -130,10 +130,10 @@ func (p *Printer) Print(args ...any) {
 			p.printString(v)
 		case rune:
 			p.printRune(v)
-		case ast.Node:
-			p.printNode(v)
 		case token.Token:
 			p.printToken(v)
+		case ast.Node:
+			p.printNode(v)
 		default:
 			panic("Unsupported type")
 		}

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -14,11 +14,8 @@ import (
 )
 
 type FactorialNode struct {
+	ast.ExprNode
 	Value string
-}
-
-func (node *FactorialNode) Type() string {
-	return "MyCustomNode"
 }
 
 func ExamplePrinter_Init() {

--- a/xjs_test.go
+++ b/xjs_test.go
@@ -71,10 +71,6 @@ type iifeExpr struct {
 	Function    *js.FunctionDecl
 }
 
-func (node *iifeExpr) Type() string {
-	return "iifeExpr"
-}
-
 func TestMiddlewares(t *testing.T) {
 	input := `(function foo() {
 		print('Hello, World!')


### PR DESCRIPTION
Remove `Type()` from the `Node` interface, so users no longer need to implement that function when defining custom nodes.

```go
// Before
type DeferStmt struct {
  ast.StmtNode
  DeferToken token.Token
  Stmt       ast.Stmt
}

func (node *DeferStmt) Type() string {
  return "DeferStmt"
}

// Now
type DeferStmt struct {
  ast.StmtNode
  DeferToken token.Token
  Stmt       ast.Stmt
}
```

The goal of these changes is to make the API easier for users to use.