### PR TITLE
refactor(ast): rename default implementations

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -14,12 +14,13 @@ type Stmt interface {
 	stmtNode()
 }
 
-type ExprNode struct{}
+// default implementations
+type (
+	BaseNode struct{}
+	BaseExpr struct{ BaseNode }
+	BaseStmt struct{ BaseNode }
+)
 
-func (ExprNode) node()     {}
-func (ExprNode) exprNode() {}
-
-type StmtNode struct{}
-
-func (StmtNode) node()     {}
-func (StmtNode) stmtNode() {}
+func (BaseNode) node()     {}
+func (BaseExpr) exprNode() {}
+func (BaseStmt) stmtNode() {}

--- a/examples/djs/main.go
+++ b/examples/djs/main.go
@@ -16,7 +16,7 @@ import (
 var deferTyp = token.RegisterType("defer")
 
 type DeferStmt struct {
-	ast.StmtNode
+	ast.BaseStmt
 	DeferToken token.Token
 	Stmt       ast.Stmt
 }

--- a/js/binary_expr.go
+++ b/js/binary_expr.go
@@ -8,7 +8,7 @@ import (
 )
 
 type BinaryExpr struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Left  ast.Expr
 	Op    token.Token
 	Right ast.Expr

--- a/js/block_stmt.go
+++ b/js/block_stmt.go
@@ -10,7 +10,7 @@ import (
 )
 
 type BlockStmt struct {
-	ast.StmtNode
+	ast.BaseStmt
 	Tokens struct {
 		Lbrace token.Token
 		Rbrace token.Token

--- a/js/call_expr.go
+++ b/js/call_expr.go
@@ -8,7 +8,7 @@ import (
 )
 
 type CallExpr struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Tokens struct {
 		Lparen token.Token
 		Rparen token.Token

--- a/js/expr.go
+++ b/js/expr.go
@@ -9,12 +9,12 @@ import (
 )
 
 type Variable struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Name token.Token
 }
 
 type Literal struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Value token.Token
 }
 

--- a/js/expr_stmt.go
+++ b/js/expr_stmt.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ExprStmt struct {
-	ast.StmtNode
+	ast.BaseStmt
 	SemiToken token.Token
 	Expr      ast.Expr
 }

--- a/js/function_decl.go
+++ b/js/function_decl.go
@@ -10,7 +10,7 @@ import (
 var FUNCTION = token.RegisterType("function")
 
 type FunctionDecl struct {
-	ast.StmtNode
+	ast.BaseStmt
 	Tokens struct {
 		Function token.Token
 		Lparen   token.Token

--- a/js/if_stmt.go
+++ b/js/if_stmt.go
@@ -13,7 +13,7 @@ var (
 )
 
 type IfStmt struct {
-	ast.StmtNode
+	ast.BaseStmt
 	Tokens struct {
 		If     token.Token
 		Lparen token.Token

--- a/js/let_stmt.go
+++ b/js/let_stmt.go
@@ -10,7 +10,7 @@ import (
 var LET = token.RegisterType("let")
 
 type LetStmt struct {
-	ast.StmtNode
+	ast.BaseStmt
 	Tokens struct {
 		Let    token.Token
 		Assign token.Token

--- a/js/paren_expr.go
+++ b/js/paren_expr.go
@@ -8,7 +8,7 @@ import (
 )
 
 type ParenExpr struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Tokens struct {
 		Lparen token.Token
 		Rparen token.Token

--- a/js/program.go
+++ b/js/program.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Program struct {
-	ast.StmtNode
+	ast.BaseStmt
 	Tokens struct {
 		EOF token.Token
 	}

--- a/js/unary_expr.go
+++ b/js/unary_expr.go
@@ -8,7 +8,7 @@ import (
 )
 
 type UnaryExpr struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Tokens struct {
 		Op token.Token
 	}

--- a/js/while_stmt.go
+++ b/js/while_stmt.go
@@ -10,7 +10,7 @@ import (
 var WHILE = token.RegisterType("while")
 
 type WhileStmt struct {
-	ast.StmtNode
+	ast.BaseStmt
 	Tokens struct {
 		While  token.Token
 		Lparen token.Token

--- a/parser/middleware_test.go
+++ b/parser/middleware_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type orExpr struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Value        ast.Expr
 	FallbackStmt ast.Stmt
 }
@@ -68,7 +68,7 @@ func TestUseExprParser(t *testing.T) {
 }
 
 type notBitwiseExpr struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Operator token.Token
 	Value    ast.Expr
 }
@@ -114,7 +114,7 @@ func TestUseUnaryParser(t *testing.T) {
 }
 
 type powExpr struct {
-	ast.ExprNode
+	ast.BaseExpr
 	LeftValue  ast.Expr
 	Operator   token.Token
 	RightValue ast.Expr
@@ -164,7 +164,7 @@ func TestUseBinaryParser(t *testing.T) {
 }
 
 type factorialExpr struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Operator token.Token
 	Value    ast.Expr
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -19,7 +19,7 @@ import (
 var updateGoldenFiles bool
 
 type MyCustomStmt struct {
-	ast.StmtNode
+	ast.BaseStmt
 	LparenToken token.Token
 	RparenToken token.Token
 	Message     token.Token

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type FactorialNode struct {
-	ast.ExprNode
+	ast.BaseExpr
 	Value string
 }
 

--- a/xjs_test.go
+++ b/xjs_test.go
@@ -65,7 +65,7 @@ func TestLanguageFeatures(t *testing.T) {
 }
 
 type iifeExpr struct {
-	ast.ExprNode
+	ast.BaseExpr
 	LparenToken token.Token
 	RparenToken token.Token
 	Function    *js.FunctionDecl


### PR DESCRIPTION
and add `BaseNode` struct.