### PR TITLE
refactor(parser): move ExpectSemi from `parser` to `js`

### DIFF
--- a/js/assign_stmt.go
+++ b/js/assign_stmt.go
@@ -28,7 +28,7 @@ func ParseAssignStmt(p *parser.Parser) (_ *AssignStmt, err error) {
 	if node.Value, err = p.ParseExpr(); err != nil {
 		return
 	}
-	if node.Layout.Semi, err = p.ExpectSemi(); err != nil {
+	if node.Layout.Semi, err = ExpectSemi(p); err != nil {
 		return
 	}
 	return node, nil

--- a/js/block_stmt.go
+++ b/js/block_stmt.go
@@ -9,6 +9,8 @@ import (
 	"github.com/xjslang/xjs/token"
 )
 
+var blockScope = parser.RegisterScope()
+
 type BlockStmt struct {
 	ast.BaseStmt
 	Layout struct {
@@ -19,6 +21,8 @@ type BlockStmt struct {
 }
 
 func ParseBlockStmt(p *parser.Parser) (_ *BlockStmt, err error) {
+	p.EnterScope(blockScope)
+	defer p.ExitScope(blockScope)
 	node := &BlockStmt{}
 	if node.Layout.Lbrace, err = p.Expect(token.LBRACE); err != nil {
 		return

--- a/js/expr_stmt.go
+++ b/js/expr_stmt.go
@@ -20,7 +20,7 @@ func ParseExprStmt(p *parser.Parser) (_ *ExprStmt, err error) {
 	if node.Expr, err = p.ParseExpr(); err != nil {
 		return
 	}
-	if node.Layout.Semi, err = p.ExpectSemi(); err != nil {
+	if node.Layout.Semi, err = ExpectSemi(p); err != nil {
 		return
 	}
 	return node, nil

--- a/js/js.go
+++ b/js/js.go
@@ -1,0 +1,29 @@
+package js
+
+import (
+	"errors"
+
+	"github.com/xjslang/xjs/parser"
+	"github.com/xjslang/xjs/token"
+)
+
+var forHeaderScope = parser.RegisterScope()
+
+func ExpectSemi(p *parser.Parser) (token.Token, error) {
+	tok := p.CurrentToken
+	if tok.Type == token.SEMICOLON {
+		if !p.InScope(forHeaderScope) {
+			p.AdvanceToken()
+		}
+		return tok, nil
+	}
+	if tok.Type == token.EOF || tok.AfterNewline ||
+		p.InScope(blockScope) && tok.Type == token.RBRACE ||
+		p.InScope(forHeaderScope) && tok.Type == token.RPAREN {
+		tok = token.Token{Type: token.SEMICOLON, Literal: token.SEMICOLON.String(), Position: tok.Position}
+		return tok, nil
+	}
+	msg := "Expected statement terminator"
+	p.AddError(msg)
+	return tok, errors.New(msg)
+}

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -1,0 +1,98 @@
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xjslang/xjs/parser"
+	"github.com/xjslang/xjs/scanner"
+	"github.com/xjslang/xjs/token"
+)
+
+func createParser(t *testing.T, input string) *parser.Parser {
+	t.Helper()
+	s := &scanner.Scanner{}
+	s.Init([]byte(input))
+	p := &parser.Parser{}
+	p.Init(s)
+	return p
+}
+
+func TestExpectSemi(t *testing.T) {
+	t.Run("no scope", func(t *testing.T) {
+		input := "hello; there"
+		p := createParser(t, input)
+		// expect ident
+		tok, err := p.Expect(token.IDENT)
+		require.NoError(t, err)
+		require.Equal(t, "hello", tok.Literal)
+		// expect semi
+		tok, err = ExpectSemi(p)
+		require.NoError(t, err)
+		// semicolon is consumed; expect identifier
+		tok, err = p.Expect(token.IDENT)
+		assert.NoError(t, err)
+		assert.Equal(t, "there", tok.Literal)
+		// expect EOF
+		tok, err = p.Expect(token.EOF)
+		require.NoError(t, err)
+	})
+
+	t.Run("block scope", func(t *testing.T) {
+		input := "hello} there"
+		p := createParser(t, input)
+		p.EnterScope(blockScope)
+		defer p.ExitScope(blockScope)
+		// expect ident
+		tok, err := p.Expect(token.IDENT)
+		require.NoError(t, err)
+		require.Equal(t, "hello", tok.Literal)
+		// '}' is a semicolon delimiter in a "block scope"
+		tok, err = ExpectSemi(p)
+		require.NoError(t, err)
+		// '}' is NOT consumed in a "block scope"
+		tok, err = p.Expect(token.RBRACE)
+		require.NoError(t, err)
+		require.Equal(t, "}", tok.Literal)
+		// expect ident
+		tok, err = p.Expect(token.IDENT)
+		require.NoError(t, err)
+		require.Equal(t, "there", tok.Literal)
+		// expect EOF
+		tok, err = p.Expect(token.EOF)
+		require.NoError(t, err)
+	})
+
+	t.Run("for scope", func(t *testing.T) {
+		input := "hello; there)"
+		p := createParser(t, input)
+		p.EnterScope(forHeaderScope)
+		defer p.ExitScope(forHeaderScope)
+		// expect ident
+		tok, err := p.Expect(token.IDENT)
+		require.NoError(t, err)
+		require.Equal(t, "hello", tok.Literal)
+		// expect semi
+		tok, err = ExpectSemi(p)
+		require.NoError(t, err)
+		// ';' is not consumed in a "for scope"
+		tok, err = p.Expect(token.SEMICOLON)
+		require.NoError(t, err)
+		require.Equal(t, ";", tok.Literal)
+		// expect ident
+		tok, err = p.Expect(token.IDENT)
+		require.NoError(t, err)
+		require.Equal(t, "there", tok.Literal)
+		// ')' is a semicolon delimiter in a "for scope"
+		tok, err = ExpectSemi(p)
+		require.NoError(t, err)
+		// ')' is not consumed in a "for scope"
+		tok, err = p.Expect(token.RPAREN)
+		require.NoError(t, err)
+		require.Equal(t, ")", tok.Literal)
+		// expect EOF
+		tok, err = p.Expect(token.EOF)
+		require.NoError(t, err)
+	})
+}

--- a/js/let_stmt.go
+++ b/js/let_stmt.go
@@ -35,7 +35,7 @@ func ParseLetStmt(p *parser.Parser) (_ *LetStmt, err error) {
 	if err != nil {
 		return
 	}
-	if node.Layout.Semi, err = p.ExpectSemi(); err != nil {
+	if node.Layout.Semi, err = ExpectSemi(p); err != nil {
 		return
 	}
 	return node, nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -149,21 +149,6 @@ func (p *Parser) Errors() ErrorList {
 	return append(ErrorList{}, p.errors...)
 }
 
-func (p *Parser) ExpectSemi() (token.Token, error) {
-	tok := p.CurrentToken
-	if tok.Type == token.SEMICOLON {
-		p.AdvanceToken()
-		return tok, nil
-	}
-	if tok.Type == token.EOF || tok.AfterNewline || slices.Contains(delimiters, tok.Type) {
-		tok = token.Token{Type: token.SEMICOLON, Literal: token.SEMICOLON.String(), Position: tok.Position}
-		return tok, nil
-	}
-	msg := "Expected statement terminator"
-	p.AddError(msg)
-	return tok, errors.New(msg)
-}
-
 func (p *Parser) AdvanceToStmtEnd() {
 	for {
 		typ := p.CurrentToken.Type

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/xjslang/xjs"
 	"github.com/xjslang/xjs/ast"
 	"github.com/xjslang/xjs/internal/testutil"
@@ -163,30 +162,6 @@ func TestExprs(t *testing.T) {
 			if got := testutil.NodeString(result); got != test.expected {
 				t.Errorf("Expected:\n\n%s\n\nGot:\n\n%s", test.expected, got)
 			}
-		})
-	}
-}
-
-func TestParser_ExpectSemi(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   string
-		nextTok token.Token
-	}{
-		{"semicolon", "hello; there", token.Token{Type: token.IDENT, Literal: "there"}},
-		{"right brace", "hello} there", token.Token{Type: token.RBRACE, Literal: "}"}},
-		{"right paren", "hello) there", token.Token{Type: token.RPAREN, Literal: ")"}},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			p := xjs.NewBuilder().Build([]byte(test.input))
-			p.AdvanceToken()
-			tok, err := p.ExpectSemi()
-			require.NoError(t, err)
-			testutil.AssertTokens(t, []token.Token{tok, p.CurrentToken}, []token.Token{
-				{Type: token.SEMICOLON, Literal: ";"},
-				test.nextTok,
-			})
 		})
 	}
 }


### PR DESCRIPTION
- The behavior of `ExpectSemi` depends of the scope.
- Prepare `ExpectSemi` for the "for statement" implementation.