### PR TITLE
refactor(printer): simplify trivia printing in blocks

### DIFF
--- a/js/array_expr.go
+++ b/js/array_expr.go
@@ -53,8 +53,7 @@ func PrintArrayExpr(p *printer.Printer, node *ArrayExpr) {
 			}
 			p.Print(val)
 		}
-		p.PrintTrivia(node.Layout.Rbracket.LeadingTrivia)
 		p.DecreaseIndent()
 	}
-	p.Print(node.Layout.Rbracket.Literal)
+	p.Print(node.Layout.Rbracket)
 }

--- a/js/block_stmt.go
+++ b/js/block_stmt.go
@@ -71,11 +71,8 @@ func PrintBlockStmt(p *printer.Printer, node *BlockStmt) {
 		if p.LastChar() != '}' && p.LastChar() != ';' {
 			p.Print(';')
 		}
-		// RBRACE is a special token, since the "leading trivia"
-		// must be printed "before" indentation level decreases
-		p.PrintTrivia(node.Layout.Rbrace.LeadingTrivia)
 		p.DecreaseIndent()
 		p.EnsureLine()
 	}
-	p.Print(node.Layout.Rbrace.Literal)
+	p.Print(node.Layout.Rbrace)
 }

--- a/js/obj_expr.go
+++ b/js/obj_expr.go
@@ -65,11 +65,8 @@ func PrintObjExpr(p *printer.Printer, node *ObjExpr) {
 			p.Print(":")
 			p.SpPrint(entry.Value)
 		}
-		// RBRACE is a special token, since the "leading trivia"
-		// must be printed "before" indentation level decreases
-		p.PrintTrivia(node.Layout.Rbrace.LeadingTrivia)
 		p.DecreaseIndent()
 		p.EnsureSpace()
 	}
-	p.Print(node.Layout.Rbrace.Literal)
+	p.Print(node.Layout.Rbrace)
 }

--- a/testdata/array.js
+++ b/testdata/array.js
@@ -6,7 +6,7 @@ let a = [
   1, // one
   2, // two
   3 // three
-  // last comment
+// last comment
 ];
 
 // complex

--- a/testdata/block_stmt.js
+++ b/testdata/block_stmt.js
@@ -1,3 +1,4 @@
 {
-  console.log("Hello, World!");
+  console.log("Hello, World!"); // prev comment
+// last comment
 }

--- a/testdata/obj.js
+++ b/testdata/obj.js
@@ -10,8 +10,8 @@ let item = {
 function foo() {
   return {
     name: 'John Smith',
-    age: 32
-    // comments here
+    age: 32 // age
+  // comments here
   };
   let item = {
     name: "John Smith",


### PR DESCRIPTION
Treating the "trivia" of `RPAREN`, `RBRACE`, or `RBRACKET` in a special way is causing more problems than it solves, by introducing complexity into the source code. Therefore, I will revoke this special treatment, even if the final formatting differs from my aesthetic expectations, which are, after all, arbitrary.