### PR TITLE
refactor(parser): show friendly errors

### DIFF
--- a/js/expr.go
+++ b/js/expr.go
@@ -63,7 +63,7 @@ func ParseValue(p *parser.Parser) (ast.Expr, error) {
 		p.AdvanceToken()
 		return &Literal{Value: val}, nil
 	}
-	msg := "Expected value"
+	msg := "Unknown expression"
 	p.AddError(msg)
 	return nil, errors.New(msg)
 }

--- a/js/stmt_block.go
+++ b/js/stmt_block.go
@@ -1,8 +1,6 @@
 package js
 
 import (
-	"errors"
-
 	"github.com/xjslang/xjs/ast"
 	"github.com/xjslang/xjs/parser"
 	"github.com/xjslang/xjs/printer"
@@ -27,7 +25,7 @@ func ParseBlockStmt(p *parser.Parser) (_ *BlockStmt, err error) {
 	if node.Layout.Lbrace, err = p.Expect(token.LBRACE); err != nil {
 		return
 	}
-	var errs []error
+	var lastError error
 	var stmt ast.Stmt
 	for i := 0; p.CurrentToken.Type != token.EOF && p.CurrentToken.Type != token.RBRACE; i++ {
 		selfClosing := false
@@ -47,7 +45,7 @@ func ParseBlockStmt(p *parser.Parser) (_ *BlockStmt, err error) {
 					// advance position to avoid infinite loop
 					p.AdvanceToken()
 				}
-				errs = append(errs, err)
+				lastError = err
 				p.AdvanceToStmtEnd()
 				continue
 			}
@@ -55,10 +53,10 @@ func ParseBlockStmt(p *parser.Parser) (_ *BlockStmt, err error) {
 		}
 	}
 	if node.Layout.Rbrace, err = p.Expect(token.RBRACE); err != nil {
-		errs = append(errs, err)
+		lastError = err
 	}
-	if len(errs) > 0 {
-		return node, errors.Join(errs...)
+	if lastError != nil {
+		return node, lastError
 	}
 	return node, nil
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2,7 +2,7 @@ package parser
 
 import (
 	"errors"
-	"strings"
+	"strconv"
 	"unicode/utf8"
 
 	"github.com/xjslang/xjs/ast"
@@ -26,11 +26,14 @@ type Error struct {
 type ErrorList []Error
 
 func (list ErrorList) Error() string {
-	var result []string
-	for _, err := range list {
-		result = append(result, err.Message)
+	if len(list) > 0 {
+		item := list[0]
+		start := item.Range.Start
+		return "[line:" + strconv.Itoa(start.Line) +
+			", col:" + strconv.Itoa(start.Column) +
+			"] " + item.Message
 	}
-	return strings.Join(result, "\n")
+	return ""
 }
 
 type Parser struct {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -182,8 +182,8 @@ func TestMalformedExpr(t *testing.T) {
 			if err == nil {
 				t.Fatal("Expected an error, got nil")
 			}
-			if got := err.Error(); got != test.expectedErr {
-				t.Fatalf("%d: Expected error to be %q, got %q", i, test.expectedErr, got)
+			if got := err.Error(); !strings.HasSuffix(got, test.expectedErr) {
+				t.Fatalf("%d: Expected %q, got %q", i, test.expectedErr, got)
 			}
 		}
 	})
@@ -306,24 +306,15 @@ func TestStmt(t *testing.T) {
 }
 
 func TestInvalidTokenAfterNewline(t *testing.T) {
-	tests := []struct {
-		input  string
-		errors []string
-	}{
-		{"\n%", []string{"Expected value"}},
-		{"let\n%", []string{"Expected identifier", "Expected value"}},
-		{"let x\n%", []string{"Expected =", "Expected value"}},
-		{"let y =\n%", []string{"Expected value", "Expected value"}},
-		{"let x =\nlet y = 1", []string{"Expected value"}},
-	}
+	tests := []string{"\n%", "let\n%", "let x\n%", "let y =\n%", "let x =\nlet y = 1"}
 	for i := range 2 {
 		for j, test := range tests {
 			t.Run(fmt.Sprintf("test %d%d", i, j), func(t *testing.T) {
 				var input string
 				if i > 0 {
-					input = fmt.Sprintf("{%s}", test.input)
+					input = fmt.Sprintf("{%s}", test)
 				} else {
-					input = test.input
+					input = test
 				}
 				p := xjs.NewBuilder().Build([]byte(input))
 				var err error
@@ -334,10 +325,6 @@ func TestInvalidTokenAfterNewline(t *testing.T) {
 				}
 				if err == nil {
 					t.Fatal("Expected an error, got nil")
-				}
-				expected := strings.Join(test.errors, "\n")
-				if got := err.Error(); got != expected {
-					t.Errorf("Expected %q, got %q", expected, got)
 				}
 			})
 		}


### PR DESCRIPTION
Now `ErrorList.Error()` returns only the first error with (line, col) info.