### PR TITLE
refactor(scanner): move consumeHexNumber to js/numbers.go

### DIFF
--- a/js/numbers.go
+++ b/js/numbers.go
@@ -1,0 +1,33 @@
+package js
+
+import (
+	"strings"
+
+	"github.com/xjslang/xjs/scanner"
+	"github.com/xjslang/xjs/token"
+)
+
+func ScanHexNumber(sc *scanner.Scanner) (string, token.Type) {
+	if c := sc.CurrentChar(); c != 'x' && c != 'X' {
+		return "", token.ILLEGAL
+	}
+	sb := strings.Builder{}
+	sb.WriteRune(sc.CurrentChar())
+	sc.AdvanceChar() // consume x | X
+	if !isHexDigit(sc.CurrentChar()) {
+		return sb.String(), token.ILLEGAL
+	}
+	sb.WriteRune(sc.CurrentChar())
+	for sc.AdvanceChar(); isHexDigit(sc.CurrentChar()); sc.AdvanceChar() {
+		sb.WriteRune(sc.CurrentChar())
+	}
+	return sb.String(), token.NUMBER
+}
+
+func isDigit(r rune) bool {
+	return r >= '0' && r <= '9'
+}
+
+func isHexDigit(r rune) bool {
+	return isDigit(r) || r >= 'a' && r <= 'f' || r >= 'A' && r <= 'F'
+}

--- a/js/numbers_test.go
+++ b/js/numbers_test.go
@@ -1,0 +1,30 @@
+package js
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xjslang/xjs/scanner"
+	"github.com/xjslang/xjs/token"
+)
+
+func TestScanHexNumber(t *testing.T) {
+	tests := []string{"x10", "X20", "xABCDEF", "xabcdef", "x123ABC", "xFFFFFF", "x0", "xF"}
+	for _, test := range tests {
+		sc := &scanner.Scanner{}
+		sc.Init([]byte(test))
+		result, typ := ScanHexNumber(sc)
+		if !assert.Equal(t, token.NUMBER, typ) {
+			continue
+		}
+		assert.Equal(t, test, result)
+	}
+
+	t.Run("invalid formats", func(t *testing.T) {
+		input := "x"
+		sc := &scanner.Scanner{}
+		sc.Init([]byte(input))
+		_, typ := ScanHexNumber(sc)
+		assert.Equal(t, token.ILLEGAL, typ)
+	})
+}

--- a/scanner/consumers.go
+++ b/scanner/consumers.go
@@ -57,24 +57,7 @@ func (sc *Scanner) consumeIdentifier() string {
 	return sb.String()
 }
 
-func (sc *Scanner) consumeHexNumber() (string, token.Type) {
-	sb := strings.Builder{}
-	// consume 0x / 0X prefix
-	for range 2 {
-		sb.WriteRune(sc.currentChar)
-		sc.AdvanceChar()
-	}
-	if !isHexDigit(sc.currentChar) {
-		return sb.String(), token.ILLEGAL
-	}
-	sb.WriteRune(sc.currentChar)
-	for sc.AdvanceChar(); isHexDigit(sc.currentChar); sc.AdvanceChar() {
-		sb.WriteRune(sc.currentChar)
-	}
-	return sb.String(), token.NUMBER
-}
-
-func (sc *Scanner) consumeDecimalNumber() (string, token.Type) {
+func (sc *Scanner) consumeNumber() (string, token.Type) {
 	sb := strings.Builder{}
 	readDigits := func() {
 		for sc.AdvanceChar(); isDigit(sc.currentChar); sc.AdvanceChar() {
@@ -101,16 +84,6 @@ func (sc *Scanner) consumeDecimalNumber() (string, token.Type) {
 		readDigits()
 	}
 	return sb.String(), token.NUMBER
-}
-
-func (sc *Scanner) consumeNumber() (string, token.Type) {
-	if sc.currentChar == '0' {
-		pc := sc.PeekChar()
-		if pc == 'x' || pc == 'X' {
-			return sc.consumeHexNumber()
-		}
-	}
-	return sc.consumeDecimalNumber()
 }
 
 func (sc *Scanner) consumeString(delimiter rune) (string, token.Type) {

--- a/scanner/consumers_test.go
+++ b/scanner/consumers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/xjslang/xjs/token"
 )
 
-func TestConsumeDecimalNumber(t *testing.T) {
+func TestConsumeNumber(t *testing.T) {
 	suffixes := []string{"", "e34", "e+34", "e-34"}
 	tests := []string{"123", "123.456", ".456", "123."}
 	for _, suffix := range suffixes {
@@ -16,7 +16,7 @@ func TestConsumeDecimalNumber(t *testing.T) {
 			input := fmt.Sprintf("%s%s", test, suffix)
 			sc := &Scanner{}
 			sc.Init([]byte(input))
-			result, typ := sc.consumeDecimalNumber()
+			result, typ := sc.consumeNumber()
 			if !assert.Equal(t, token.NUMBER, typ) {
 				continue
 			}
@@ -29,29 +29,8 @@ func TestConsumeDecimalNumber(t *testing.T) {
 		for _, test := range tests {
 			sc := &Scanner{}
 			sc.Init([]byte(test))
-			_, typ := sc.consumeDecimalNumber()
+			_, typ := sc.consumeNumber()
 			assert.Equal(t, token.ILLEGAL, typ)
 		}
-	})
-}
-
-func TestConsumeHexNumber(t *testing.T) {
-	tests := []string{"0x10", "0X20", "0xABCDEF", "0xabcdef", "0x123ABC", "0xFFFFFF", "0x0", "0xF"}
-	for _, test := range tests {
-		sc := &Scanner{}
-		sc.Init([]byte(test))
-		result, typ := sc.consumeNumber()
-		if !assert.Equal(t, token.NUMBER, typ) {
-			continue
-		}
-		assert.Equal(t, test, result)
-	}
-
-	t.Run("invalid formats", func(t *testing.T) {
-		input := "0x"
-		sc := &Scanner{}
-		sc.Init([]byte(input))
-		_, typ := sc.consumeNumber()
-		assert.Equal(t, token.ILLEGAL, typ)
 	})
 }

--- a/scanner/helpers.go
+++ b/scanner/helpers.go
@@ -7,7 +7,3 @@ func isLetter(r rune) bool {
 func isDigit(r rune) bool {
 	return r >= '0' && r <= '9'
 }
-
-func isHexDigit(r rune) bool {
-	return isDigit(r) || r >= 'a' && r <= 'f' || r >= 'A' && r <= 'F'
-}

--- a/xjs.go
+++ b/xjs.go
@@ -90,28 +90,36 @@ func jsPlugin(b *builder.Builder) {
 
 	b.UseScanner(func(sc *scanner.Scanner, next func() token.Token) (tok token.Token) {
 		tok = next()
-		if tok.Type != token.IDENT {
-			return
-		}
-		switch tok.Literal {
-		case "function":
-			tok.Type = js.FUNCTION
-		case "let":
-			tok.Type = js.LET
-		case "if":
-			tok.Type = js.IF
-		case "else":
-			tok.Type = js.ELSE
-		case "while":
-			tok.Type = js.WHILE
-		case "for":
-			tok.Type = js.FOR
-		case "return":
-			tok.Type = js.RETURN
-		case "break":
-			tok.Type = js.BREAK
-		case "continue":
-			tok.Type = js.CONTINUE
+		switch tok.Type {
+		case token.IDENT:
+			switch tok.Literal {
+			case "function":
+				tok.Type = js.FUNCTION
+			case "let":
+				tok.Type = js.LET
+			case "if":
+				tok.Type = js.IF
+			case "else":
+				tok.Type = js.ELSE
+			case "while":
+				tok.Type = js.WHILE
+			case "for":
+				tok.Type = js.FOR
+			case "return":
+				tok.Type = js.RETURN
+			case "break":
+				tok.Type = js.BREAK
+			case "continue":
+				tok.Type = js.CONTINUE
+			}
+		case token.NUMBER:
+			if tok.Literal == "0" {
+				switch sc.CurrentChar() {
+				case 'x', 'X':
+					lit, typ := js.ScanHexNumber(sc)
+					return token.Token{Type: typ, Literal: tok.Literal + lit}
+				}
+			}
 		}
 		return
 	})


### PR DESCRIPTION
and rename it to `ScanHexNumber`.

This is a first step towards moving the functions from `xjs/scanner/consumers.go` to the `js` folder, so that the Scanner is JavaScript agnostic.