### PR TITLE
refactor(scanner,token): remove token.BOOLEAN

### DIFF
--- a/js/expr.go
+++ b/js/expr.go
@@ -58,7 +58,7 @@ func ParseValue(p *parser.Parser) (ast.Expr, error) {
 		val := p.CurrentToken
 		p.AdvanceToken()
 		return &Variable{Name: val}, nil
-	case token.NUMBER, token.STRING, token.BOOLEAN:
+	case token.NUMBER, token.STRING:
 		val := p.CurrentToken
 		p.AdvanceToken()
 		return &Literal{Value: val}, nil

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -174,8 +174,7 @@ func defaultScanner(sc *Scanner) token.Token {
 	default:
 		if isLetter(sc.currentChar) {
 			lit := scanIdentifier(sc)
-			typ := lookup(lit)
-			return token.Token{Type: typ, Literal: lit}
+			return token.Token{Type: token.IDENT, Literal: lit}
 		} else if isDigit(sc.currentChar) {
 			lit, typ := scanNumber(sc)
 			return token.Token{Type: typ, Literal: lit}
@@ -191,12 +190,4 @@ func defaultScanner(sc *Scanner) token.Token {
 	c := sc.currentChar
 	sc.AdvanceChar()
 	return token.Token{Type: token.UNKNOWN, Literal: string(c)}
-}
-
-func lookup(lit string) token.Type {
-	switch lit {
-	case "true", "false":
-		return token.BOOLEAN
-	}
-	return token.IDENT
 }

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func assertLexerTokens(t *testing.T, sc *scanner.Scanner, expectedToks []token.Token, opts ...testutil.TokenCompareOption) {
+	t.Helper()
 	var toks []token.Token
 	for {
 		tok := sc.NextToken()
@@ -23,6 +24,7 @@ func assertLexerTokens(t *testing.T, sc *scanner.Scanner, expectedToks []token.T
 }
 
 func assertInputTokens(t *testing.T, input string, expectedToks []token.Token, opts ...testutil.TokenCompareOption) {
+	t.Helper()
 	sc := &scanner.Scanner{}
 	sc.Init([]byte(input))
 	assertLexerTokens(t, sc, expectedToks, opts...)
@@ -302,14 +304,6 @@ func TestReadIdent(t *testing.T) {
 func TestReadNumber(t *testing.T) {
 	assertInputTokens(t, "123", []token.Token{
 		{Type: token.NUMBER, Literal: "123"},
-		{Type: token.EOF},
-	})
-}
-
-func TestReadBoolean(t *testing.T) {
-	assertInputTokens(t, "true false", []token.Token{
-		{Type: token.BOOLEAN, Literal: "true"},
-		{Type: token.BOOLEAN, Literal: "false"},
 		{Type: token.EOF},
 	})
 }

--- a/token/token.go
+++ b/token/token.go
@@ -39,7 +39,6 @@ const (
 	// literals
 	STRING
 	NUMBER
-	BOOLEAN
 	// operators
 	ASSIGN   // =
 	PLUS     // +
@@ -85,9 +84,8 @@ var tokenLiterals = map[Type]string{
 	ILLEGAL: "illegal",
 	UNKNOWN: "unknown",
 	// literals
-	STRING:  "string",
-	NUMBER:  "number",
-	BOOLEAN: "boolean",
+	STRING: "string",
+	NUMBER: "number",
 	// operators
 	ASSIGN:   "=",
 	PLUS:     "+",


### PR DESCRIPTION
Now `true` / `false` are evaluated as any other identifier. There is no reason to treat them as "special identifiers".

This changes add a breaking API change.