### PR TITLE
refactor(printer): make the printer JS agnostic

### DIFF
--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -229,12 +229,12 @@ func TestKeysAreSaved(t *testing.T) {
 			[]token.Token{
 				{Type: token.LBRACE, Literal: "{", LeadingTrivia: []token.Token{
 					{Type: token.NEWLINE, Literal: "\n"},
-					{Type: token.LINE_COMMENT, Literal: " comment before {\n"},
+					{Type: token.LINE_COMMENT, Literal: "// comment before {\n"},
 					{Type: token.NEWLINE, Literal: "\n"},
 				}},
 				{Type: token.RBRACE, Literal: "}", LeadingTrivia: []token.Token{
-					{Type: token.LINE_COMMENT, Literal: " comment before }\n"},
-					{Type: token.BLOCK_COMMENT, Literal: " block comment "},
+					{Type: token.LINE_COMMENT, Literal: "// comment before }\n"},
+					{Type: token.BLOCK_COMMENT, Literal: "/* block comment */"},
 				}},
 			},
 			testutil.CompareLeadingTrivia(),
@@ -254,10 +254,10 @@ func TestKeysAreSaved(t *testing.T) {
 			[]token.Token{result.Layout.Lparen, result.Layout.Rparen},
 			[]token.Token{
 				{Type: token.LPAREN, Literal: "(", LeadingTrivia: []token.Token{
-					{Type: token.LINE_COMMENT, Literal: " comment before\n"},
+					{Type: token.LINE_COMMENT, Literal: "// comment before\n"},
 				}},
 				{Type: token.RPAREN, Literal: ")", LeadingTrivia: []token.Token{
-					{Type: token.LINE_COMMENT, Literal: " comment after\n"},
+					{Type: token.LINE_COMMENT, Literal: "// comment after\n"},
 				}},
 			},
 			testutil.CompareLeadingTrivia(),

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -30,19 +30,17 @@ func (list ErrorList) Error() string {
 }
 
 type config struct {
-	indent        string
-	lineComments  bool
-	blockComments bool
-	newLines      bool
+	indent       string
+	withComments bool
+	withNewLines bool
 }
 
 type Option func(*config)
 
 func Compact() Option {
 	return func(cfg *config) {
-		cfg.lineComments = false
-		cfg.blockComments = false
-		cfg.newLines = false
+		cfg.withComments = false
+		cfg.withNewLines = false
 	}
 }
 
@@ -54,43 +52,29 @@ func WithIndent(value string) Option {
 
 func WithComments(value bool) Option {
 	return func(cfg *config) {
-		cfg.lineComments = value
-		cfg.blockComments = value
-	}
-}
-
-func WithLineComments(value bool) Option {
-	return func(cfg *config) {
-		cfg.lineComments = value
-	}
-}
-
-func WithBlockComments(value bool) Option {
-	return func(cfg *config) {
-		cfg.blockComments = value
+		cfg.withComments = value
 	}
 }
 
 func WithNewLines(value bool) Option {
 	return func(cfg *config) {
-		cfg.newLines = value
+		cfg.withNewLines = value
 	}
 }
 
 type Printer struct {
-	doc           strings.Builder
-	lineComments  bool
-	blockComments bool
-	newLines      bool
-	indent        string
-	indentLevel   int
-	lastChar      rune
-	ensureBeside  bool
-	ensureLine    bool
-	ensureSpace   bool
-	printer       func(*Printer, ast.Node) error
-	context       []map[string]string
-	errors        ErrorList
+	doc          strings.Builder
+	withComments bool
+	withNewLines bool
+	indent       string
+	indentLevel  int
+	lastChar     rune
+	ensureBeside bool
+	ensureLine   bool
+	ensureSpace  bool
+	printer      func(*Printer, ast.Node) error
+	context      []map[string]string
+	errors       ErrorList
 }
 
 // Init initializes the printer.
@@ -99,18 +83,16 @@ type Printer struct {
 // Printer middleware can be registered via UsePrinter BEFORE Init.
 func (p *Printer) Init(opts ...Option) {
 	cfg := &config{
-		lineComments:  true,
-		blockComments: true,
-		newLines:      true,
-		indent:        "  ",
+		withComments: true,
+		withNewLines: true,
+		indent:       "  ",
 	}
 	for _, opt := range opts {
 		opt(cfg)
 	}
 	p.doc.Reset()
-	p.lineComments = cfg.lineComments
-	p.blockComments = cfg.blockComments
-	p.newLines = cfg.newLines
+	p.withComments = cfg.withComments
+	p.withNewLines = cfg.withNewLines
 	p.indent = cfg.indent
 	p.indentLevel = 0
 	p.lastChar = eol
@@ -197,28 +179,21 @@ func (p *Printer) SpPrint(arg any) {
 }
 
 func (p *Printer) PrintTrivia(trivia []token.Token) {
+	eb, es, el := p.ensureBeside, p.ensureSpace, p.ensureLine
 	for _, tok := range trivia {
-		switch tok.Type {
-		case token.NEWLINE:
-			if !p.newLines {
-				continue
+		if tok.Type == token.NEWLINE {
+			if p.withNewLines {
+				p.writeRune('\n')
 			}
-			p.writeRune('\n')
-		case token.LINE_COMMENT:
-			if !p.lineComments {
-				continue
-			}
+			continue
+		}
+		if p.withComments {
 			p.printSpaceIfNeeded()
 			p.printIndentIfNeeded()
-			p.writeString("//" + tok.Literal)
-		case token.BLOCK_COMMENT:
-			if !p.blockComments {
-				continue
-			}
-			p.printIndentIfNeeded()
-			p.writeString("/*" + tok.Literal + "*/")
+			p.writeString(tok.Literal)
 		}
 	}
+	p.ensureBeside, p.ensureSpace, p.ensureLine = eb, es, el
 }
 
 func (p *Printer) Errors() ErrorList {
@@ -268,7 +243,7 @@ func (p *Printer) printToken(tok token.Token) {
 }
 
 func (p *Printer) printLineIfNeeded() {
-	if p.newLines && !isNewLine(p.lastChar) {
+	if p.withNewLines && !isNewLine(p.lastChar) {
 		p.writeRune('\n')
 	}
 }

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -122,7 +122,7 @@ func TestPrintCallExpr(t *testing.T) {
 				3 * 4 // c3
 				// c4
 			) - 5) - 3`,
-			expected: `let x = 1 * (foo/* c1 */(
+			expected: `let x = 1 * (foo /* c1 */(
   2, // c2
   3 * 4 // c3
 // c4
@@ -356,8 +356,6 @@ func TestWithComments(t *testing.T) {
 		{"show comments by default", xjs.NewPrinter()},
 		{"hide comments", xjs.NewPrinter(printer.WithComments(false))},
 		{"show comments", xjs.NewPrinter(printer.WithComments(true))},
-		{"hide lcomments and show bcomments", xjs.NewPrinter(printer.WithLineComments(false), printer.WithBlockComments(true))},
-		{"show lcomments and hide bcomments", xjs.NewPrinter(printer.WithLineComments(true), printer.WithBlockComments(false))},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/printer/util.go
+++ b/printer/util.go
@@ -12,9 +12,8 @@ func ErrorAt(tok token.Token, msg string) error {
 func Fork(p *Printer) *Printer {
 	p1 := &Printer{printer: p.printer}
 	p1.Init(
-		WithLineComments(p.lineComments),
-		WithBlockComments(p.blockComments),
-		WithNewLines(p.newLines),
+		WithComments(p.withComments),
+		WithNewLines(p.withNewLines),
 		WithIndent(p.indent),
 	)
 	return p1

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -115,12 +115,12 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 		switch s.currentChar {
 		case '/':
 			comment := scanLineComment(s)
-			tok = token.Token{Type: token.LINE_COMMENT, Literal: comment}
+			tok = token.Token{Type: token.LINE_COMMENT, Literal: "//" + comment}
 		case '*':
 			var comment string
 			comment, err = scanBlockComment(s)
 			// TODO: (high) https://github.com/xjslang/xjs/pull/260#discussion_r3439298639
-			tok = token.Token{Type: token.BLOCK_COMMENT, Literal: comment}
+			tok = token.Token{Type: token.BLOCK_COMMENT, Literal: "/*" + comment}
 		default:
 			tok = token.Token{Type: token.DIVIDE, Literal: string(c1)}
 		}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -175,11 +175,11 @@ func TestBlockComments(t *testing.T) {
 	input := "/* lorem\nipsum dolor */\n\rhello\r\n/* unfinished comment"
 	assertInputTokens(t, input, []token.Token{
 		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []token.Token{
-			{Type: token.BLOCK_COMMENT, Literal: " lorem\nipsum dolor "},
+			{Type: token.BLOCK_COMMENT, Literal: "/* lorem\nipsum dolor */"},
 			{Type: token.NEWLINE, Literal: "\n"},
 			{Type: token.NEWLINE, Literal: "\r"},
 		}},
-		{Type: token.ILLEGAL, Literal: " unfinished comment", LeadingTrivia: []token.Token{
+		{Type: token.ILLEGAL, Literal: "/* unfinished comment", LeadingTrivia: []token.Token{
 			{Type: token.NEWLINE, Literal: "\r\n"},
 		}},
 		{Type: token.EOF},
@@ -198,17 +198,17 @@ func TestLineComments(t *testing.T) {
 	assertInputTokens(t, input, []token.Token{
 		{Type: token.IDENT, Literal: "John", LeadingTrivia: []token.Token{
 			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: token.LINE_COMMENT, Literal: " First Name\n"},
+			{Type: token.LINE_COMMENT, Literal: "// First Name\n"},
 		}},
 		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: []token.Token{
 			{Type: token.NEWLINE, Literal: "\n"},
 			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: token.LINE_COMMENT, Literal: " Last Name\n"},
+			{Type: token.LINE_COMMENT, Literal: "// Last Name\n"},
 		}},
 		{Type: token.EOF, LeadingTrivia: []token.Token{
 			{Type: token.NEWLINE, Literal: "\n"},
 			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: token.LINE_COMMENT, Literal: " Final comment"},
+			{Type: token.LINE_COMMENT, Literal: "// Final comment"},
 		}},
 	}, testutil.CompareLeadingTrivia())
 }
@@ -216,20 +216,20 @@ func TestLineComments(t *testing.T) {
 func TestEmptySinglelineComment(t *testing.T) {
 	assertInputTokens(t, "//\nhello//\n\npeople//\r\nthere//\r!//", []token.Token{
 		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "\n"},
+			{Type: token.LINE_COMMENT, Literal: "//\n"},
 		}},
 		{Type: token.IDENT, Literal: "people", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "\n"},
+			{Type: token.LINE_COMMENT, Literal: "//\n"},
 			{Type: token.NEWLINE, Literal: "\n"},
 		}},
 		{Type: token.IDENT, Literal: "there", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "\r\n"},
+			{Type: token.LINE_COMMENT, Literal: "//\r\n"},
 		}},
 		{Type: token.NOT, Literal: "!", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "\r"},
+			{Type: token.LINE_COMMENT, Literal: "//\r"},
 		}},
 		{Type: token.EOF, Literal: "", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT},
+			{Type: token.LINE_COMMENT, Literal: "//"},
 		}},
 	}, testutil.CompareLeadingTrivia())
 }
@@ -237,7 +237,7 @@ func TestEmptySinglelineComment(t *testing.T) {
 func TestLastLineComment(t *testing.T) {
 	assertInputTokens(t, "// last comment", []token.Token{
 		{Type: token.EOF, Literal: "", AfterNewline: false, LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: " last comment"},
+			{Type: token.LINE_COMMENT, Literal: "// last comment"},
 		}},
 	}, testutil.CompareLeadingTrivia(), testutil.CompareAfterNewline())
 }

--- a/scanner/scanners.go
+++ b/scanner/scanners.go
@@ -10,9 +10,11 @@ func scanBlockComment(sc *Scanner) (string, error) {
 	sc.AdvanceChar() // consume "*"
 	for {
 		if sc.currentChar == '*' && sc.PeekChar() == '/' {
-			// skip "*/"
-			sc.AdvanceChar()
-			sc.AdvanceChar()
+			// consume "*/"
+			for range 2 {
+				sb.WriteRune(sc.currentChar)
+				sc.AdvanceChar()
+			}
 			break
 		} else if sc.currentChar == eof {
 			return sb.String(), errors.New("unexpected end of file")


### PR DESCRIPTION
Now the printer does not know specific JS features, such as "line comments" or "block comments".