### PR TITLE
fix: several bug fixes across scanner, parser, token and builder

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -46,7 +46,9 @@ func (b *Builder) Install(plugin func(b *Builder)) *Builder {
 }
 
 func (b *Builder) Build(src []byte) *parser.Parser {
-	b.scanner.Init(src, scanner.WithCommentTypes(js.LINE_COMMENT, js.BLOCK_COMMENT))
-	b.parser.Init(b.scanner)
-	return b.parser
+	sc := *b.scanner
+	p := *b.parser
+	sc.Init(src, scanner.WithCommentTypes(js.LINE_COMMENT, js.BLOCK_COMMENT))
+	p.Init(&sc)
+	return &p
 }

--- a/js/stmt_if.go
+++ b/js/stmt_if.go
@@ -55,20 +55,16 @@ func ParseIfStmt(p *parser.Parser) (node *IfStmt, err error) {
 		return
 	}
 	// then
-	if p.CurrentToken.Type == token.LBRACE {
-		if node.Then, err = p.ParseStmt(); err != nil {
+	if node.Then, err = p.ParseStmt(); err != nil {
+		return
+	}
+	// else
+	if p.CurrentToken.Type == ELSE {
+		node.Layout.Else = p.CurrentToken
+		p.AdvanceToken()
+		if node.Else, err = p.ParseStmt(); err != nil {
 			return
 		}
-		// else
-		if p.CurrentToken.Type == ELSE {
-			node.Layout.Else = p.CurrentToken
-			p.AdvanceToken()
-			if node.Else, err = p.ParseStmt(); err != nil {
-				return
-			}
-		}
-	} else if node.Then, err = p.ParseStmt(); err != nil {
-		return
 	}
 	return
 }

--- a/scanner/helpers.go
+++ b/scanner/helpers.go
@@ -1,7 +1,9 @@
 package scanner
 
+import "unicode"
+
 func IsLetter(r rune) bool {
-	return r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r == '_' || r == '$'
+	return r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r == '_' || r == '$' || r > 127 && unicode.IsLetter(r)
 }
 
 func IsDigit(r rune) bool {

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -150,7 +150,6 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 		c := s.currentChar
 		s.AdvanceChar()
 		tok = token.Token{Type: token.LBRACKET, Literal: string(c)}
-		return
 	case ']':
 		c := s.currentChar
 		s.AdvanceChar()

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -27,6 +27,7 @@ type Scanner struct {
 	scanner      func(*Scanner) (token.Token, error)
 	currentChar  rune
 	triviaTypes  []token.Type
+	lastErr      error
 }
 
 // Init initializes the scanner.
@@ -54,7 +55,13 @@ func (sc *Scanner) Reset() {
 	sc.currentChar = EOF
 	sc.line = 0
 	sc.column = -1
+	sc.lastErr = nil
 	sc.AdvanceChar()
+}
+
+// Err returns the last error encountered during scanning, if any.
+func (sc *Scanner) Err() error {
+	return sc.lastErr
 }
 
 func (sc *Scanner) CurrentChar() rune {
@@ -101,9 +108,9 @@ func (sc *Scanner) NextToken() token.Token {
 		sc.skipWhitespaces()
 		line, column := sc.line, sc.column
 		tok, err := sc.scanner(sc)
-		// TODO: (medium) Scanner.NextToken converts scanner/middleware errors into token.ILLEGAL but discards the error value entirely. With the new middleware signature returning errors, callers still have no way to observe why a token is illegal other than inspecting Literal. Consider exposing the error (e.g., NextToken returning (token.Token, error) or storing the last error on Scanner) so downstream code can surface better diagnostics.
 		if err != nil {
 			tok.Type = token.ILLEGAL
+			sc.lastErr = err
 		}
 		tok.Line = line
 		tok.Column = max(0, column)

--- a/testdata/if.js
+++ b/testdata/if.js
@@ -11,6 +11,9 @@ if (hello) {
   console.log("Bye bye, World!");
 }
 
+// else with non-block then
+if (hello) console.log("Hello, World!") else console.log("Bye bye, World!");
+
 // nested
 if (one) {
   console.log("aaa");

--- a/token/token.go
+++ b/token/token.go
@@ -128,6 +128,10 @@ var (
 func RegisterType(lit string) Type {
 	registerMu.Lock()
 	defer registerMu.Unlock()
+	return registerType(lit)
+}
+
+func registerType(lit string) Type {
 	typ := nextType
 	tokenLiterals[typ] = lit
 	nextType++
@@ -182,8 +186,10 @@ func RegisterBinaryType(typ Type, precedence int) {
 
 // RegisterBinaryOp registers a "binary operator".
 func RegisterBinaryOp(lit string, precedence int) Type {
-	typ := RegisterType(lit)
-	RegisterBinaryType(typ, precedence)
+	registerMu.Lock()
+	defer registerMu.Unlock()
+	typ := registerType(lit)
+	binaryOps[typ] = precedence
 	return typ
 }
 
@@ -212,7 +218,9 @@ func RegisterUnaryType(typ Type) {
 
 // RegisterUnaryOp registers a "unary operator".
 func RegisterUnaryOp(lit string) Type {
-	typ := RegisterType(lit)
-	RegisterUnaryType(typ)
+	registerMu.Lock()
+	defer registerMu.Unlock()
+	typ := registerType(lit)
+	unaryTypes[typ] = true
 	return typ
 }

--- a/xjs_fixes_test.go
+++ b/xjs_fixes_test.go
@@ -1,0 +1,137 @@
+package xjs_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xjslang/xjs"
+	"github.com/xjslang/xjs/js"
+	"github.com/xjslang/xjs/token"
+)
+
+func TestIfElseNonBlockThen(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "else after single-statement then",
+			input:    `if (x) foo() else bar()`,
+			expected: `if (x) foo() else bar();`,
+		},
+		{
+			name:     "else after single-statement then with newlines",
+			input:    "if (x)\n  foo()\nelse\n  bar()",
+			expected: "if (x)\nfoo()\nelse\nbar();",
+		},
+		{
+			name:     "else-if chain with non-block first then",
+			input:    `if (a) foo() else if (b) bar() else baz()`,
+			expected: `if (a) foo() else if (b) bar() else baz();`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := xjs.Parse([]byte(tt.input))
+			require.NoError(t, err)
+			pr := xjs.NewPrinter()
+			pr.Init()
+			pr.Print(result)
+			out, err := pr.Output()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, out)
+		})
+	}
+}
+
+func TestDollarSignIdentifier(t *testing.T) {
+	tests := []string{
+		`let $el = 1`,
+		`let $$ = 2`,
+		`$scope.apply()`,
+	}
+	for _, src := range tests {
+		t.Run(src, func(t *testing.T) {
+			_, err := xjs.Parse([]byte(src))
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestUnicodeIdentifier(t *testing.T) {
+	tests := []string{
+		`let café = 1`,
+		`let π = 3`,
+		`let über = 4`,
+	}
+	for _, src := range tests {
+		t.Run(src, func(t *testing.T) {
+			_, err := xjs.Parse([]byte(src))
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestRegisterBinaryOpRace(t *testing.T) {
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			typ := token.RegisterBinaryOp("~~", 5)
+			assert.True(t, typ.IsBinaryOp())
+		}()
+	}
+	wg.Wait()
+}
+
+func TestRegisterUnaryOpRace(t *testing.T) {
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			typ := token.RegisterUnaryOp("^^")
+			assert.True(t, typ.IsUnaryOp())
+		}()
+	}
+	wg.Wait()
+}
+
+func TestScannerErrExposed(t *testing.T) {
+	_, err := xjs.Parse([]byte(`"unterminated`))
+	require.Error(t, err)
+}
+
+func TestBuilderBuildIndependence(t *testing.T) {
+	b := xjs.NewBuilder()
+
+	p1 := b.Build([]byte(`let x = 1`))
+	p2 := b.Build([]byte(`let y = 2`))
+
+	prog1, err := js.ParseProgram(p1)
+	require.NoError(t, err)
+
+	prog2, err := js.ParseProgram(p2)
+	require.NoError(t, err)
+
+	pr1 := xjs.NewPrinter()
+	pr1.Init()
+	pr1.Print(prog1)
+	out1, _ := pr1.Output()
+
+	pr2 := xjs.NewPrinter()
+	pr2.Init()
+	pr2.Print(prog2)
+	out2, _ := pr2.Output()
+
+	assert.True(t, strings.Contains(out1, "x"))
+	assert.True(t, strings.Contains(out2, "y"))
+	assert.False(t, strings.Contains(out1, "y"))
+}


### PR DESCRIPTION
Found a few bugs while reading through the code:

- `js/stmt_if.go`: `else` was being ignored when the `then` branch had no braces. `if (x) foo() else bar()` would silently drop the else.

- `scanner/helpers.go`: `IsLetter` didn't handle Unicode letters so identifiers like `café` or `π` couldn't be parsed.

- `scanner/middleware.go`: The `[` case in `defaultScanner` has a stray `return` that every other case doesn't have.

- `token/token.go`: `RegisterBinaryOp` and `RegisterUnaryOp` acquired the lock twice in separate calls, leaving a small race window. Fixed by doing both writes under one lock.

- `scanner/scanner.go`: Resolved the TODO — scanner errors were being swallowed. Added `Err()` so callers can see why a token came back as `ILLEGAL`.

- `builder/builder.go`: Calling `Build()` twice on the same builder would overwrite the first returned parser. It now returns independent instances.