### PR TITLE
refactor(printer): remove BsPrint, LnPrint and SpPrint

### DIFF
--- a/examples/djs/main.go
+++ b/examples/djs/main.go
@@ -75,7 +75,7 @@ func main() {
 		UsePrinter(func(pr *printer.Printer, node ast.Node, next func(ast.Node) error) error {
 			if node, ok := node.(*DeferStmt); ok {
 				pr.PrintTrivia(node.DeferToken.LeadingTrivia) // print previous comments and new lines
-				pr.LnPrint("{using _ = {[Symbol.dispose]() {")
+				pr.Line().Print("{using _ = {[Symbol.dispose]() {")
 				pr.Print(node.Stmt)
 				pr.Print("}}}")
 				return nil
@@ -93,9 +93,9 @@ func main() {
 	djsFormatter := xjs.PrinterBuilder().
 		UsePrinter(func(pr *printer.Printer, node ast.Node, next func(ast.Node) error) error {
 			if node, ok := node.(*DeferStmt); ok {
-				pr.EnsureLine() // ensure a new line is added before printing
+				pr.Line() // ensure a new line is added before printing
 				pr.Print(node.DeferToken)
-				pr.EnsureSpace() // ensure a new space is added before printing
+				pr.Space() // ensure a new space is added before printing
 				if deferNode, ok := node.Stmt.(*js.ExprStmt); ok {
 					pr.Print(deferNode.Expr)
 				} else {

--- a/examples/jsx/formatter.go
+++ b/examples/jsx/formatter.go
@@ -10,13 +10,13 @@ func Formatter(pr *printer.Printer, node ast.Node, next func(node ast.Node) erro
 	case *ConcatExpr:
 		pr.Print(v.Left, " | ", v.Right)
 	case *Tag:
-		pr.SpPrint("<").Print(v.Name, ">")
+		pr.Space().Print("<").Print(v.Name, ">")
 		pr.IncreaseIndent()
 		if v.Children != nil {
-			pr.LnPrint(v.Children)
+			pr.Line().Print(v.Children)
 		}
 		pr.DecreaseIndent()
-		pr.LnPrint("</").Print(v.Name, ">")
+		pr.Line().Print("</").Print(v.Name, ">")
 	default:
 		return next(node)
 	}

--- a/js/expr_array.go
+++ b/js/expr_array.go
@@ -45,7 +45,7 @@ func PrintArrayExpr(p *printer.Printer, node *ArrayExpr) {
 		for i, val := range node.Values {
 			if i > 0 {
 				p.Print(",")
-				p.EnsureSpace()
+				p.Space()
 			}
 			p.Print(val)
 		}

--- a/js/expr_binary.go
+++ b/js/expr_binary.go
@@ -26,6 +26,6 @@ func ParseBinaryExpr(p *parser.Parser, left ast.Expr) (node *BinaryExpr, err err
 
 func PrintBinaryExpr(p *printer.Printer, node *BinaryExpr) {
 	p.Print(node.Left)
-	p.SpPrint(node.Op)
-	p.SpPrint(node.Right)
+	p.Space().Print(node.Op)
+	p.Space().Print(node.Right)
 }

--- a/js/expr_call.go
+++ b/js/expr_call.go
@@ -44,7 +44,7 @@ func PrintCallExpr(p *printer.Printer, node *CallExpr) {
 	for i, arg := range node.Args {
 		if i > 0 {
 			p.Print(",")
-			p.EnsureSpace()
+			p.Space()
 		}
 		p.Print(arg)
 	}

--- a/js/expr_function.go
+++ b/js/expr_function.go
@@ -53,7 +53,7 @@ func ParseFunctionExpr(p *parser.Parser) (node *FunctionExpr, err error) {
 
 func PrintFunctionExpr(p *printer.Printer, node *FunctionExpr) {
 	p.Print(node.Layout.Function)
-	p.EnsureSpace()
+	p.Space()
 	if node.Name != nil {
 		p.Print(node.Name)
 	}
@@ -62,11 +62,11 @@ func PrintFunctionExpr(p *printer.Printer, node *FunctionExpr) {
 	for i, param := range node.Params {
 		if i > 0 {
 			p.Print(",")
-			p.EnsureSpace()
+			p.Space()
 		}
 		p.Print(param)
 	}
 	p.DecreaseIndent()
 	p.Print(node.Layout.Rparen)
-	p.SpPrint(node.Body)
+	p.Space().Print(node.Body)
 }

--- a/js/expr_obj.go
+++ b/js/expr_obj.go
@@ -106,15 +106,15 @@ func PrintObjExpr(p *printer.Printer, node *ObjExpr) {
 			}
 			switch v := entry.Key.(type) {
 			case *ComputedExpr:
-				p.SpPrint(v.Layout.Lbracket).Print(v.Expr, v.Layout.Rbracket)
+				p.Space().Print(v.Layout.Lbracket).Print(v.Expr, v.Layout.Rbracket)
 			default:
-				p.SpPrint(v)
+				p.Space().Print(v)
 			}
 			p.Print(":")
-			p.SpPrint(entry.Value)
+			p.Space().Print(entry.Value)
 		}
 		p.DecreaseIndent()
-		p.EnsureSpace()
+		p.Space()
 	}
 	p.Print(node.Layout.Rbrace)
 }

--- a/js/stmt_assign.go
+++ b/js/stmt_assign.go
@@ -31,7 +31,7 @@ func ParseAssignStmt(p *parser.Parser) (node *AssignStmt, err error) {
 }
 
 func PrintAssignStmt(p *printer.Printer, node *AssignStmt) {
-	p.LnPrint(node.Name)
-	p.SpPrint(node.Layout.Assign)
-	p.SpPrint(node.Value)
+	p.Line().Print(node.Name)
+	p.Space().Print(node.Layout.Assign)
+	p.Space().Print(node.Value)
 }

--- a/js/stmt_block.go
+++ b/js/stmt_block.go
@@ -82,7 +82,7 @@ func PrintBlockStmt(p *printer.Printer, node *BlockStmt) {
 			p.Print(';')
 		}
 		p.DecreaseIndent()
-		p.EnsureLine()
+		p.Line()
 	}
 	p.Print(node.Layout.Rbrace)
 }

--- a/js/stmt_break.go
+++ b/js/stmt_break.go
@@ -31,8 +31,8 @@ func ParseBreakStmt(p *parser.Parser) (node *BreakStmt, err error) {
 }
 
 func PrintBreakStmt(p *printer.Printer, node *BreakStmt) {
-	p.LnPrint(node.Layout.Break)
+	p.Line().Print(node.Layout.Break)
 	if node.Label != nil {
-		p.SpPrint(node.Label)
+		p.Space().Print(node.Label)
 	}
 }

--- a/js/stmt_continue.go
+++ b/js/stmt_continue.go
@@ -31,8 +31,8 @@ func ParseContinueStmt(p *parser.Parser) (node *ContinueStmt, err error) {
 }
 
 func PrintContinueStmt(p *printer.Printer, node *ContinueStmt) {
-	p.LnPrint(node.Layout.Continue)
+	p.Line().Print(node.Layout.Continue)
 	if node.Label != nil {
-		p.SpPrint(node.Label)
+		p.Space().Print(node.Label)
 	}
 }

--- a/js/stmt_dec.go
+++ b/js/stmt_dec.go
@@ -27,6 +27,6 @@ func ParseDecStmt(p *parser.Parser) (node *DecStmt, err error) {
 }
 
 func PrintDecStmt(p *printer.Printer, node *DecStmt) {
-	p.LnPrint(node.Name)
+	p.Line().Print(node.Name)
 	p.Print(node.Layout.Decrement)
 }

--- a/js/stmt_expr.go
+++ b/js/stmt_expr.go
@@ -20,5 +20,5 @@ func ParseExprStmt(p *parser.Parser) (node *ExprStmt, err error) {
 }
 
 func PrintExprStmt(p *printer.Printer, node *ExprStmt) {
-	p.LnPrint(node.Expr)
+	p.Line().Print(node.Expr)
 }

--- a/js/stmt_for.go
+++ b/js/stmt_for.go
@@ -141,8 +141,8 @@ func parseAfterClause(p *parser.Parser) (node ast.Stmt, err error) {
 
 func PrintForStmt(p *printer.Printer, node *ForStmt) {
 	// for
-	p.LnPrint(node.Layout.For)
-	p.SpPrint(node.Layout.Lparen)
+	p.Line().Print(node.Layout.For)
+	p.Space().Print(node.Layout.Lparen)
 	// (init; condition; after)
 	p.IncreaseIndent()
 	if node.Init != nil {
@@ -150,7 +150,7 @@ func PrintForStmt(p *printer.Printer, node *ForStmt) {
 	}
 	p.Print(node.Layout.Semi1)
 	if node.Cond != nil {
-		p.SpPrint(node.Cond)
+		p.Space().Print(node.Cond)
 	}
 	p.Print(node.Layout.Semi2)
 	if node.After != nil {
@@ -159,20 +159,20 @@ func PrintForStmt(p *printer.Printer, node *ForStmt) {
 	p.DecreaseIndent()
 	// then
 	p.Print(node.Layout.Rparen)
-	p.SpPrint(node.Then)
+	p.Space().Print(node.Then)
 }
 
 func printInitClause(p *printer.Printer, node ast.Stmt) {
 	switch v := node.(type) {
 	case *LetStmt:
 		p.Print(v.Layout.Let)
-		p.SpPrint(v.Name)
-		p.SpPrint(v.Layout.Assign)
-		p.SpPrint(v.Value)
+		p.Space().Print(v.Name)
+		p.Space().Print(v.Layout.Assign)
+		p.Space().Print(v.Value)
 	case *AssignStmt:
 		p.Print(v.Name)
-		p.SpPrint(v.Layout.Assign)
-		p.SpPrint(v.Value)
+		p.Space().Print(v.Layout.Assign)
+		p.Space().Print(v.Value)
 	default:
 		panic("unexpected init clause type")
 	}
@@ -181,10 +181,10 @@ func printInitClause(p *printer.Printer, node ast.Stmt) {
 func printAfterClause(p *printer.Printer, node ast.Stmt) {
 	switch v := node.(type) {
 	case *IncStmt:
-		p.SpPrint(v.Name)
+		p.Space().Print(v.Name)
 		p.Print(v.Layout.Increment)
 	case *DecStmt:
-		p.SpPrint(v.Name)
+		p.Space().Print(v.Name)
 		p.Print(v.Layout.Decrement)
 	default:
 		panic("unexpected after clause type")

--- a/js/stmt_function.go
+++ b/js/stmt_function.go
@@ -57,18 +57,18 @@ func ParseFunctionDecl(p *parser.Parser) (node *FunctionDecl, err error) {
 }
 
 func PrintFunctionDecl(p *printer.Printer, node *FunctionDecl) {
-	p.LnPrint(node.Layout.Function)
-	p.SpPrint(node.Name)
+	p.Line().Print(node.Layout.Function)
+	p.Space().Print(node.Name)
 	p.Print(node.Layout.Lparen)
 	p.IncreaseIndent()
 	for i, param := range node.Params {
 		if i > 0 {
 			p.Print(",")
-			p.EnsureSpace()
+			p.Space()
 		}
 		p.Print(param)
 	}
 	p.DecreaseIndent()
 	p.Print(node.Layout.Rparen)
-	p.SpPrint(node.Body)
+	p.Space().Print(node.Body)
 }

--- a/js/stmt_if.go
+++ b/js/stmt_if.go
@@ -75,13 +75,13 @@ func ParseIfStmt(p *parser.Parser) (node *IfStmt, err error) {
 
 func PrintIfStmt(p *printer.Printer, node *IfStmt) {
 	// if (condition) stmt
-	p.LnPrint(node.Layout.If)
-	p.SpPrint(node.Layout.Lparen)
+	p.Line().Print(node.Layout.If)
+	p.Space().Print(node.Layout.Lparen)
 	p.Print(node.Cond, node.Layout.Rparen)
-	p.SpPrint(node.Then)
+	p.Space().Print(node.Then)
 	// else
 	if node.Else != nil {
-		p.SpPrint(node.Layout.Else)
-		p.SpPrint(node.Else)
+		p.Space().Print(node.Layout.Else)
+		p.Space().Print(node.Else)
 	}
 }

--- a/js/stmt_inc.go
+++ b/js/stmt_inc.go
@@ -27,6 +27,6 @@ func ParseIncStmt(p *parser.Parser) (node *IncStmt, err error) {
 }
 
 func PrintIncStmt(p *printer.Printer, node *IncStmt) {
-	p.LnPrint(node.Name)
+	p.Line().Print(node.Name)
 	p.Print(node.Layout.Increment)
 }

--- a/js/stmt_label.go
+++ b/js/stmt_label.go
@@ -39,5 +39,5 @@ func ParseLabelStmt(p *parser.Parser) (node *LabelStmt, err error) {
 
 func PrintLabelStmt(p *printer.Printer, node *LabelStmt) {
 	p.Print(node.Name, node.Layout.Colon)
-	p.SpPrint(node.Stmt)
+	p.Space().Print(node.Stmt)
 }

--- a/js/stmt_let.go
+++ b/js/stmt_let.go
@@ -38,8 +38,8 @@ func ParseLetStmt(p *parser.Parser) (node *LetStmt, err error) {
 }
 
 func PrintLetStmt(p *printer.Printer, node *LetStmt) {
-	p.LnPrint(node.Layout.Let)
-	p.SpPrint(node.Name)
-	p.SpPrint(node.Layout.Assign)
-	p.SpPrint(node.Value)
+	p.Line().Print(node.Layout.Let)
+	p.Space().Print(node.Name)
+	p.Space().Print(node.Layout.Assign)
+	p.Space().Print(node.Value)
 }

--- a/js/stmt_return.go
+++ b/js/stmt_return.go
@@ -32,8 +32,8 @@ func ParseReturnStmt(p *parser.Parser) (node *ReturnStmt, err error) {
 }
 
 func PrintReturnStmt(p *printer.Printer, node *ReturnStmt) {
-	p.LnPrint(node.Layout.Return)
+	p.Line().Print(node.Layout.Return)
 	if node.Value != nil {
-		p.SpPrint(node.Value)
+		p.Space().Print(node.Value)
 	}
 }

--- a/js/stmt_while.go
+++ b/js/stmt_while.go
@@ -51,8 +51,8 @@ func ParseWhileStmt(p *parser.Parser) (node *WhileStmt, err error) {
 }
 
 func PrintWhileStmt(p *printer.Printer, node *WhileStmt) {
-	p.LnPrint(node.Layout.While)
-	p.SpPrint(node.Layout.Lparen)
+	p.Line().Print(node.Layout.While)
+	p.Space().Print(node.Layout.Lparen)
 	p.Print(node.Cond, node.Layout.Rparen)
-	p.SpPrint(node.Then)
+	p.Space().Print(node.Then)
 }

--- a/printer/context_test.go
+++ b/printer/context_test.go
@@ -83,8 +83,8 @@ func TestPrinterContext(t *testing.T) {
 				ctx := pr.PushContext()
 				defer pr.PopContext()
 				ctx["async"] = "yes"
-				pr.LnPrint(v.Layout.Async)
-				pr.SpPrint(v.FunctionDecl)
+				pr.Line().Print(v.Layout.Async)
+				pr.Space().Print(v.FunctionDecl)
 				return nil
 			case *AwaitStmt:
 				ctx := pr.Context()
@@ -92,8 +92,8 @@ func TestPrinterContext(t *testing.T) {
 				if !ok {
 					return printer.ErrorAt(v.Layout.Await, "await is allowed only inside async functions")
 				}
-				pr.LnPrint(v.Layout.Await)
-				pr.SpPrint(v.Expr)
+				pr.Line().Print(v.Layout.Await)
+				pr.Space().Print(v.Expr)
 				return nil
 			}
 			return next(node)

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -117,26 +117,26 @@ func (p *Printer) PrintIndent() {
 	}
 }
 
-// EnsureBeside ensures that the next text to print appears "beside" the previous text.
-func (p *Printer) EnsureBeside() *Printer {
+// Beside ensures that the next text to print appears "beside" the previous text.
+func (p *Printer) Beside() *Printer {
 	p.ensureBeside = true
 	return p
 }
 
-// EnsureLine ensures that a newline is printed before printing the next text.
+// Line ensures that a newline is printed before printing the next text.
 //
 // It does not print a newline immediately, but "ensures" that a newline is printed
 // between the current print and the next print.
-func (p *Printer) EnsureLine() *Printer {
+func (p *Printer) Line() *Printer {
 	p.ensureLine = true
 	return p
 }
 
-// EnsureSpace ensures that a space is printed before printing the next text.
+// Space ensures that a space is printed before printing the next text.
 //
 // It does not print a space immediately, but "ensures" that a space is printed
 // between the current print and the next print "on the same line".
-func (p *Printer) EnsureSpace() *Printer {
+func (p *Printer) Space() *Printer {
 	p.ensureSpace = true
 	return p
 }
@@ -159,26 +159,6 @@ func (p *Printer) Print(args ...any) *Printer {
 		}
 	}
 	return p
-}
-
-// BsPrint ensures that the next text to print appears "beside" the previous text.
-// This is a combination of EnsureBeside() + Print(a).
-// It takes priority over LnPrint() and SpPrint().
-func (p *Printer) BsPrint(arg any) *Printer {
-	return p.EnsureBeside().Print(arg)
-}
-
-// LnPrint ensures that a newline is printed before printing the next text.
-// This is a combination of EnsureLine() + Print(a).
-func (p *Printer) LnPrint(arg any) *Printer {
-	return p.EnsureLine().Print(arg)
-}
-
-// SpPrint ensures that a space is printed before printing the next text.
-// This is a combination of EnsureSpace() + Print(a).
-// It takes priority over LnPrint().
-func (p *Printer) SpPrint(arg any) *Printer {
-	return p.EnsureSpace().Print(arg)
 }
 
 func (p *Printer) PrintTrivia(trivia []token.Token) {

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -42,11 +42,11 @@ func TestInit(t *testing.T) {
 		pr := printer.NewBuilder().Build(printer.WithIndent("\t"))
 		pr.Print("begin:")
 		pr.IncreaseIndent()
-		pr.LnPrint("aaa")
-		pr.LnPrint("bbb")
-		pr.LnPrint("ccc")
+		pr.Line().Print("aaa")
+		pr.Line().Print("bbb")
+		pr.Line().Print("ccc")
 		pr.DecreaseIndent()
-		pr.LnPrint("end")
+		pr.Line().Print("end")
 		out, err := pr.Output()
 		require.NoError(t, err)
 		require.Equal(t, "begin:\n\taaa\n\tbbb\n\tccc\nend", out)
@@ -173,26 +173,26 @@ func TestLastComment(t *testing.T) {
 	}
 }
 
-func TestEnsureLine(t *testing.T) {
+func TestLine(t *testing.T) {
 	pr := printer.NewBuilder().Build()
-	// calling EnsureLine at the beginning of a document does not print a new line
-	pr.EnsureLine()
+	// calling Line at the beginning of a document does not print a new line
+	pr.Line()
 	pr.Print("aaa")
-	// calling EnsureLine multiple times only prints a new line (it is idempotent)
+	// calling Line multiple times only prints a new line (it is idempotent)
 	for range 2 {
-		pr.EnsureLine()
+		pr.Line()
 	}
 	pr.Print("bbb")
-	// calling EnsureLine on a `\n` line does not print a new line
+	// calling Line on a `\n` line does not print a new line
 	pr.Print("ccc\n")
-	pr.EnsureLine()
+	pr.Line()
 	pr.Print("ddd")
-	// calling EnsureLine on a `\r` line does not print a new line
+	// calling Line on a `\r` line does not print a new line
 	pr.Print("eee\r")
-	pr.EnsureLine()
+	pr.Line()
 	pr.Print("fff")
 	// printing empty string does not reset `ensureLine`
-	pr.EnsureLine()
+	pr.Line()
 	pr.Print("")
 	pr.Print("")
 	pr.Print("ggg")
@@ -206,7 +206,7 @@ func TestEnsureLine(t *testing.T) {
 	t.Run("printing empty string does not consume ensureLine", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
 		pr.Print("aaa")
-		pr.EnsureLine()
+		pr.Line()
 		pr.Print("")
 		out, err := pr.Output()
 		require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestEnsureLine(t *testing.T) {
 	t.Run("printing empty string does not consume ensureSpace", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
 		pr.Print("aaa")
-		pr.EnsureSpace()
+		pr.Space()
 		pr.Print("")
 		out, err := pr.Output()
 		require.NoError(t, err)
@@ -224,26 +224,26 @@ func TestEnsureLine(t *testing.T) {
 	})
 }
 
-func TestEnsureSpace(t *testing.T) {
+func TestSpace(t *testing.T) {
 	pr := printer.NewBuilder().Build()
-	// calling EnsureSpace at the beginning of a document does not print a new space
-	pr.EnsureSpace()
+	// calling Space at the beginning of a document does not print a new space
+	pr.Space()
 	pr.Print("aaa")
-	// calling EnsureSpace multiple times only prints a new space (it is idempotent)
+	// calling Space multiple times only prints a new space (it is idempotent)
 	for range 2 {
-		pr.EnsureSpace()
+		pr.Space()
 	}
 	pr.Print("bbb")
-	// calling EnsureSpace on a `\n` line does not print a new space
+	// calling Space on a `\n` line does not print a new space
 	pr.Print("ccc\n")
-	pr.EnsureSpace()
+	pr.Space()
 	pr.Print("ddd")
-	// calling EnsureSpace on a `\r` line does not print a new space
+	// calling Space on a `\r` line does not print a new space
 	pr.Print("eee\r")
-	pr.EnsureSpace()
+	pr.Space()
 	pr.Print("fff")
 	// printing empty string does not reset `ensureSpace`
-	pr.EnsureSpace()
+	pr.Space()
 	pr.Print("")
 	pr.Print("")
 	pr.Print("ggg")
@@ -260,24 +260,24 @@ type MyCustomStmt struct {
 	name string
 }
 
-func TestEnsureBeside(t *testing.T) {
+func TestBeside(t *testing.T) {
 	pr := printer.NewBuilder().
 		UsePrinter(func(p *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
 			if v, ok := node.(*MyCustomStmt); ok {
-				p.LnPrint(v.name)
+				p.Line().Print(v.name)
 				return nil
 			}
 			return next(node)
 		}).
 		Build()
 	pr.Print("aaa")
-	// EnsureBeside takes priority over EnsureSpace and EnsureLine
-	pr.EnsureBeside()
-	pr.SpPrint("bbb")
-	pr.EnsureBeside()
-	pr.LnPrint("bbb")
-	// EnsureBeside takes priority over custom printers
-	pr.BsPrint(&MyCustomStmt{name: "custom_stmt"})
+	// Beside takes priority over Space and Line
+	pr.Beside()
+	pr.Space().Print("bbb")
+	pr.Beside()
+	pr.Line().Print("bbb")
+	// Beside takes priority over custom printers
+	pr.Beside().Print(&MyCustomStmt{name: "custom_stmt"})
 	out, err := pr.Output()
 	require.NoError(t, err)
 	require.Equal(t, "aaabbbbbbcustom_stmt", out)
@@ -287,8 +287,8 @@ func TestPrint(t *testing.T) {
 	t.Run("append newlines and spaces before printing runes", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
 		pr.Print("aaa")
-		pr.LnPrint('b')
-		pr.SpPrint('c')
+		pr.Line().Print('b')
+		pr.Space().Print('c')
 		out, err := pr.Output()
 		require.NoError(t, err)
 		require.Equal(t, "aaa\nb c", out)
@@ -299,12 +299,12 @@ func TestPrint(t *testing.T) {
 	})
 }
 
-func TestLnPrint(t *testing.T) {
+func TestLineAndPrint(t *testing.T) {
 	t.Run("new line is added before printing", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
-		pr.LnPrint("aaa")
-		pr.LnPrint("bbb")
-		pr.LnPrint("ccc")
+		pr.Line().Print("aaa")
+		pr.Line().Print("bbb")
+		pr.Line().Print("ccc")
 		out, err := pr.Output()
 		require.NoError(t, err)
 		require.Equal(t, "aaa\nbbb\nccc", out)
@@ -315,43 +315,43 @@ func TestSpacesTakePriorityOverLines(t *testing.T) {
 	pr := xjs.PrinterBuilder().Build()
 	pr.Print("aaa")
 	// ensureSpace should take priority over ensureLine (by default statements are printed in a new line)
-	pr.SpPrint(&js.ExprStmt{Expr: &js.Literal{Value: token.Token{Literal: "125"}}})
+	pr.Space().Print(&js.ExprStmt{Expr: &js.Literal{Value: token.Token{Literal: "125"}}})
 	out, err := pr.Output()
 	require.NoError(t, err)
 	require.Equal(t, "aaa 125", out)
 }
 
-func TestSpPrint(t *testing.T) {
+func TestSpaceAndPrint(t *testing.T) {
 	pr := printer.NewBuilder().Build()
-	pr.SpPrint("aaa")
-	pr.SpPrint("bbb")
+	pr.Space().Print("aaa")
+	pr.Space().Print("bbb")
 	out, err := pr.Output()
 	require.NoError(t, err)
 	require.Equal(t, "aaa bbb", out)
 }
 
 func TestPrintPriority(t *testing.T) {
-	t.Run("EnsureBeside takes priority over EnsureSpace and EnsureLine", func(t *testing.T) {
+	t.Run("Beside takes priority over Space and Line", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
 		pr.Print("a").
-			EnsureBeside().SpPrint("b").
-			EnsureBeside().LnPrint("c")
+			Beside().Space().Print("b").
+			Beside().Line().Print("c")
 		out, err := pr.Output()
 		require.NoError(t, err)
 		require.Equal(t, "abc", out)
 	})
-	t.Run("EnsureSpace takes priority over EnsureLine", func(t *testing.T) {
+	t.Run("Space takes priority over Line", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
 		pr.Print("a").
-			EnsureSpace().LnPrint("b")
+			Space().Line().Print("b")
 		out, err := pr.Output()
 		require.NoError(t, err)
 		require.Equal(t, "a b", out)
 	})
-	t.Run("EnsureLine has the lowest priority", func(t *testing.T) {
+	t.Run("Line has the lowest priority", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
 		pr.Print("a").
-			EnsureLine().Print("b")
+			Line().Print("b")
 		out, err := pr.Output()
 		require.NoError(t, err)
 		require.Equal(t, "a\nb", out)


### PR DESCRIPTION
and rename EnsureBeside, EnsureLine y EnsureSpace to Beside, Line and Space respectively.

This introduces a breaking API change.