### PR TITLE
refactor(printer): change Print signature

### DIFF
--- a/examples/jsx/formatter.go
+++ b/examples/jsx/formatter.go
@@ -10,13 +10,13 @@ func Formatter(pr *printer.Printer, node ast.Node, next func(node ast.Node) erro
 	case *ConcatExpr:
 		pr.Print(v.Left, " | ", v.Right)
 	case *Tag:
-		pr.Space().Print("<").Print(v.Name, ">")
+		pr.Space().Print("<", v.Name, ">")
 		pr.IncreaseIndent()
 		if v.Children != nil {
 			pr.Line().Print(v.Children)
 		}
 		pr.DecreaseIndent()
-		pr.Line().Print("</").Print(v.Name, ">")
+		pr.Line().Print("</", v.Name, ">")
 	default:
 		return next(node)
 	}

--- a/js/expr_assign.go
+++ b/js/expr_assign.go
@@ -30,6 +30,8 @@ func ParseAssignExpr(p *parser.Parser, left ast.Expr) (node *AssignExpr, err err
 func PrintAssignExpr(pr *printer.Printer, node *AssignExpr) error {
 	pr.Log("(")
 	defer pr.Log(")")
-	pr.Print(node.Left).Space().Print(node.Layout.Assign).Space().Print(node.Right)
+	pr.Print(node.Left)
+	pr.Space().Print(node.Layout.Assign)
+	pr.Space().Print(node.Right)
 	return nil
 }

--- a/js/expr_dec.go
+++ b/js/expr_dec.go
@@ -24,6 +24,6 @@ func ParseDecExpr(p *parser.Parser, left ast.Expr) (node *DecExpr, err error) {
 }
 
 func PrintDecExpr(pr *printer.Printer, node *DecExpr) error {
-	pr.Print(node.Left).Print(node.Layout.Decrement)
+	pr.Print(node.Left, node.Layout.Decrement)
 	return nil
 }

--- a/js/expr_inc.go
+++ b/js/expr_inc.go
@@ -24,6 +24,6 @@ func ParseIncExpr(p *parser.Parser, left ast.Expr) (node *IncExpr, err error) {
 }
 
 func PrintIncExpr(pr *printer.Printer, node *IncExpr) error {
-	pr.Print(node.Left).Print(node.Layout.Increment)
+	pr.Print(node.Left, node.Layout.Increment)
 	return nil
 }

--- a/js/expr_obj.go
+++ b/js/expr_obj.go
@@ -106,7 +106,8 @@ func PrintObjExpr(pr *printer.Printer, node *ObjExpr) error {
 			}
 			switch v := entry.Key.(type) {
 			case *ComputedExpr:
-				pr.Space().Print(v.Layout.Lbracket).Print(v.Expr, v.Layout.Rbracket)
+				pr.Space().Print(v.Layout.Lbracket)
+				pr.Print(v.Expr, v.Layout.Rbracket)
 			default:
 				pr.Space().Print(v)
 			}

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -158,7 +158,7 @@ func (pr *Printer) Space() *Printer {
 	return pr.Ensure(' ')
 }
 
-func (pr *Printer) Print(args ...any) *Printer {
+func (pr *Printer) Print(args ...any) {
 	for _, arg := range args {
 		switch v := arg.(type) {
 		case string:
@@ -175,14 +175,12 @@ func (pr *Printer) Print(args ...any) *Printer {
 			panic("Unsupported type")
 		}
 	}
-	return pr
 }
 
-func (pr *Printer) Log(args ...any) *Printer {
+func (pr *Printer) Log(args ...any) {
 	if pr.withLogs {
-		return pr.Print(args...)
+		pr.Print(args...)
 	}
-	return pr
 }
 
 func (pr *Printer) PrintTrivia(trivia []token.Token) {

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -357,25 +357,25 @@ func TestSpaceAndPrint(t *testing.T) {
 func TestPrintPriority(t *testing.T) {
 	t.Run("Beside takes priority over Space and Line", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
-		pr.Print("a").
-			Beside().Space().Print("b").
-			Beside().Line().Print("c")
+		pr.Print("a")
+		pr.Beside().Space().Print("b")
+		pr.Beside().Line().Print("c")
 		out, err := pr.Output()
 		require.NoError(t, err)
 		require.Equal(t, "abc", out)
 	})
 	t.Run("Space takes priority over Line", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
-		pr.Print("a").
-			Space().Line().Print("b")
+		pr.Print("a")
+		pr.Space().Line().Print("b")
 		out, err := pr.Output()
 		require.NoError(t, err)
 		require.Equal(t, "a b", out)
 	})
 	t.Run("Line has the lowest priority", func(t *testing.T) {
 		pr := printer.NewBuilder().Build()
-		pr.Print("a").
-			Line().Print("b")
+		pr.Print("a")
+		pr.Line().Print("b")
 		out, err := pr.Output()
 		require.NoError(t, err)
 		require.Equal(t, "a\nb", out)


### PR DESCRIPTION
I have changed the signature of the `Print` function to not return the "receiver", since the function already accepts multiple parameters, so allowing "chaining" was, in some way, redundant and generated code like the following:
```go
pr.Print("a", "b", "c").Print("d")

// can be written like
pr.Print("a", "b", "c", "d")
```
However, I have maintained chaining in the `Ensure`, `Beside`, `Line`, and `Space` functions because it is common for these functions to precede a `Print` call.

This PR introduces a breaking API change.