### PR TITLE
refactor(scanner): move comment scanners from `js` to `scanner` package

### DIFF
--- a/js/scanners.go
+++ b/js/scanners.go
@@ -9,57 +9,9 @@ import (
 )
 
 var (
-	LINE_COMMENT  = token.RegisterType("//")
-	BLOCK_COMMENT = token.RegisterType("/*")
-	NUMBER        = token.RegisterType("number")
-	STRING        = token.RegisterType("string")
+	NUMBER = token.RegisterType("number")
+	STRING = token.RegisterType("string")
 )
-
-func ScanLineComment(s *scanner.Scanner) string {
-	sb := strings.Builder{}
-	sb.WriteString("//")
-	for {
-		s.AdvanceChar()
-		if s.CurrentChar() == '\n' {
-			sb.WriteRune(s.CurrentChar())
-			s.AdvanceChar()
-			break
-		} else if s.CurrentChar() == '\r' {
-			sb.WriteRune(s.CurrentChar())
-			s.AdvanceChar()
-			if s.CurrentChar() == '\n' {
-				sb.WriteRune(s.CurrentChar())
-				s.AdvanceChar()
-			}
-			break
-		} else if s.CurrentChar() == scanner.EOF {
-			break
-		}
-		sb.WriteRune(s.CurrentChar())
-	}
-	return sb.String()
-}
-
-func ScanBlockComment(sc *scanner.Scanner) (string, error) {
-	sb := strings.Builder{}
-	sb.WriteString("/*")
-	sc.AdvanceChar() // consume "*"
-	for {
-		if sc.CurrentChar() == '*' && sc.PeekChar() == '/' {
-			// consume "*/"
-			for range 2 {
-				sb.WriteRune(sc.CurrentChar())
-				sc.AdvanceChar()
-			}
-			break
-		} else if sc.CurrentChar() == scanner.EOF {
-			return sb.String(), errors.New("unexpected end of file")
-		}
-		sb.WriteRune(sc.CurrentChar())
-		sc.AdvanceChar()
-	}
-	return sb.String(), nil
-}
 
 func ScanString(sc *scanner.Scanner, delimiter rune) (string, error) {
 	sb := strings.Builder{}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -291,12 +291,12 @@ func TestKeysAreSaved(t *testing.T) {
 			[]token.Token{
 				{Type: token.LBRACE, Literal: "{", LeadingTrivia: []token.Token{
 					{Type: token.NEWLINE, Literal: "\n"},
-					{Type: js.LINE_COMMENT, Literal: "// comment before {\n"},
+					{Type: token.LINE_COMMENT, Literal: "// comment before {\n"},
 					{Type: token.NEWLINE, Literal: "\n"},
 				}},
 				{Type: token.RBRACE, Literal: "}", LeadingTrivia: []token.Token{
-					{Type: js.LINE_COMMENT, Literal: "// comment before }\n"},
-					{Type: js.BLOCK_COMMENT, Literal: "/* block comment */"},
+					{Type: token.LINE_COMMENT, Literal: "// comment before }\n"},
+					{Type: token.BLOCK_COMMENT, Literal: "/* block comment */"},
 				}},
 			},
 			testutil.CompareLeadingTrivia(),
@@ -316,10 +316,10 @@ func TestKeysAreSaved(t *testing.T) {
 			[]token.Token{result.Layout.Lparen, result.Layout.Rparen},
 			[]token.Token{
 				{Type: token.LPAREN, Literal: "(", LeadingTrivia: []token.Token{
-					{Type: js.LINE_COMMENT, Literal: "// comment before\n"},
+					{Type: token.LINE_COMMENT, Literal: "// comment before\n"},
 				}},
 				{Type: token.RPAREN, Literal: ")", LeadingTrivia: []token.Token{
-					{Type: js.LINE_COMMENT, Literal: "// comment after\n"},
+					{Type: token.LINE_COMMENT, Literal: "// comment after\n"},
 				}},
 			},
 			testutil.CompareLeadingTrivia(),

--- a/plugin/builder.go
+++ b/plugin/builder.go
@@ -2,7 +2,6 @@ package plugin
 
 import (
 	"github.com/xjslang/xjs/ast"
-	"github.com/xjslang/xjs/js"
 	"github.com/xjslang/xjs/parser"
 	"github.com/xjslang/xjs/scanner"
 	"github.com/xjslang/xjs/token"
@@ -46,6 +45,6 @@ func (b *Builder) Install(plugin func(b *Builder)) *Builder {
 }
 
 func (b *Builder) Build(src []byte) *parser.Parser {
-	s := b.scanner.Build(src, scanner.WithCommentTypes(js.LINE_COMMENT, js.BLOCK_COMMENT))
+	s := b.scanner.Build(src)
 	return b.parser.Build(s)
 }

--- a/scanner/builder.go
+++ b/scanner/builder.go
@@ -15,11 +15,11 @@ func (b *Builder) UseScanner(scanner func(s *Scanner, next func() (token.Token, 
 	return b
 }
 
-func (b *Builder) Build(input []byte, opts ...func(*config)) *Scanner {
+func (b *Builder) Build(input []byte) *Scanner {
 	s := &Scanner{}
 	for _, scanner := range b.scanners {
 		s.useScanner(scanner)
 	}
-	s.init(input, opts...)
+	s.init(input)
 	return s
 }

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -112,7 +112,18 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 	case '/':
 		c := s.currentChar
 		s.AdvanceChar()
-		tok = token.Token{Type: token.DIVIDE, Literal: string(c)}
+		switch s.currentChar {
+		case '/':
+			lit := ScanLineComment(s)
+			tok = token.Token{Type: token.LINE_COMMENT, Literal: lit}
+		case '*':
+			tok = token.Token{Type: token.BLOCK_COMMENT}
+			if tok.Literal, err = ScanBlockComment(s); err != nil {
+				return
+			}
+		default:
+			tok = token.Token{Type: token.DIVIDE, Literal: string(c)}
+		}
 	// delimiters
 	case '\'', '"':
 		c := s.currentChar

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -1,22 +1,11 @@
 package scanner
 
 import (
-	"slices"
 	"strings"
 	"unicode/utf8"
 
 	"github.com/xjslang/xjs/token"
 )
-
-type config struct {
-	withTriviaTypes []token.Type
-}
-
-func WithCommentTypes(typ ...token.Type) func(*config) {
-	return func(cfg *config) {
-		cfg.withTriviaTypes = append(cfg.withTriviaTypes, typ...)
-	}
-}
 
 const EOF = rune(-1)
 
@@ -26,15 +15,9 @@ type Scanner struct {
 	line, column int
 	scanner      func(*Scanner) (token.Token, error)
 	currentChar  rune
-	triviaTypes  []token.Type
 }
 
-func (sc *Scanner) init(input []byte, opts ...func(*config)) {
-	cfg := &config{}
-	for _, opt := range opts {
-		opt(cfg)
-	}
-	sc.triviaTypes = cfg.withTriviaTypes
+func (sc *Scanner) init(input []byte) {
 	sc.input = input
 	if sc.scanner == nil {
 		sc.scanner = defaultScanner
@@ -49,7 +32,6 @@ func (sc *Scanner) Fork() token.Scanner {
 		line:        sc.line,
 		column:      sc.column,
 		currentChar: sc.currentChar,
-		triviaTypes: slices.Clone(sc.triviaTypes),
 	}
 	s.scanner = sc.scanner
 	if s.scanner == nil {
@@ -138,10 +120,10 @@ func (sc *Scanner) NextToken() token.Token {
 	tok := next()
 triviaLoop:
 	for {
-		switch {
-		case tok.Type == token.NEWLINE:
+		switch tok.Type {
+		case token.NEWLINE:
 			afterNewline = true
-		case slices.Contains(sc.triviaTypes, tok.Type):
+		case token.LINE_COMMENT, token.BLOCK_COMMENT:
 			afterNewline = afterNewline || strings.ContainsAny(tok.Literal, "\n\r")
 		default:
 			break triviaLoop

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -41,22 +41,10 @@ func assertInputTokens(t *testing.T, input string, expectedToks []token.Token, o
 					return
 				}
 				tok.Literal += lit
-			case token.DIVIDE:
-				switch s.CurrentChar() {
-				case '/':
-					tok.Type = js.LINE_COMMENT
-					tok.Literal = js.ScanLineComment(s)
-				case '*':
-					tok.Type = js.BLOCK_COMMENT
-					if tok.Literal, err = js.ScanBlockComment(s); err != nil {
-						tok.Type = token.ILLEGAL
-						return
-					}
-				}
 			}
 			return
 		}).
-		Build([]byte(input), scanner.WithCommentTypes(js.LINE_COMMENT, js.BLOCK_COMMENT))
+		Build([]byte(input))
 	assertLexerTokens(t, s, expectedToks, opts...)
 }
 
@@ -251,7 +239,7 @@ func TestBlockComments(t *testing.T) {
 	input := "/* lorem\nipsum dolor */\n\rhello\r\n/* unfinished comment"
 	assertInputTokens(t, input, []token.Token{
 		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []token.Token{
-			{Type: js.BLOCK_COMMENT, Literal: "/* lorem\nipsum dolor */"},
+			{Type: token.BLOCK_COMMENT, Literal: "/* lorem\nipsum dolor */"},
 			{Type: token.NEWLINE, Literal: "\n"},
 			{Type: token.NEWLINE, Literal: "\r"},
 		}},
@@ -274,17 +262,17 @@ func TestLineComments(t *testing.T) {
 	assertInputTokens(t, input, []token.Token{
 		{Type: token.IDENT, Literal: "John", LeadingTrivia: []token.Token{
 			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: js.LINE_COMMENT, Literal: "// First Name\n"},
+			{Type: token.LINE_COMMENT, Literal: "// First Name\n"},
 		}},
 		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: []token.Token{
 			{Type: token.NEWLINE, Literal: "\n"},
 			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: js.LINE_COMMENT, Literal: "// Last Name\n"},
+			{Type: token.LINE_COMMENT, Literal: "// Last Name\n"},
 		}},
 		{Type: token.EOF, LeadingTrivia: []token.Token{
 			{Type: token.NEWLINE, Literal: "\n"},
 			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: js.LINE_COMMENT, Literal: "// Final comment"},
+			{Type: token.LINE_COMMENT, Literal: "// Final comment"},
 		}},
 	}, testutil.CompareLeadingTrivia())
 }
@@ -292,20 +280,20 @@ func TestLineComments(t *testing.T) {
 func TestEmptySinglelineComment(t *testing.T) {
 	assertInputTokens(t, "//\nhello//\n\npeople//\r\nthere//\r!//", []token.Token{
 		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []token.Token{
-			{Type: js.LINE_COMMENT, Literal: "//\n"},
+			{Type: token.LINE_COMMENT, Literal: "//\n"},
 		}},
 		{Type: token.IDENT, Literal: "people", LeadingTrivia: []token.Token{
-			{Type: js.LINE_COMMENT, Literal: "//\n"},
+			{Type: token.LINE_COMMENT, Literal: "//\n"},
 			{Type: token.NEWLINE, Literal: "\n"},
 		}},
 		{Type: token.IDENT, Literal: "there", LeadingTrivia: []token.Token{
-			{Type: js.LINE_COMMENT, Literal: "//\r\n"},
+			{Type: token.LINE_COMMENT, Literal: "//\r\n"},
 		}},
 		{Type: token.NOT, Literal: "!", LeadingTrivia: []token.Token{
-			{Type: js.LINE_COMMENT, Literal: "//\r"},
+			{Type: token.LINE_COMMENT, Literal: "//\r"},
 		}},
 		{Type: token.EOF, Literal: "", LeadingTrivia: []token.Token{
-			{Type: js.LINE_COMMENT, Literal: "//"},
+			{Type: token.LINE_COMMENT, Literal: "//"},
 		}},
 	}, testutil.CompareLeadingTrivia())
 }
@@ -313,7 +301,7 @@ func TestEmptySinglelineComment(t *testing.T) {
 func TestLastLineComment(t *testing.T) {
 	assertInputTokens(t, "// last comment", []token.Token{
 		{Type: token.EOF, Literal: "", AfterNewline: false, LeadingTrivia: []token.Token{
-			{Type: js.LINE_COMMENT, Literal: "// last comment"},
+			{Type: token.LINE_COMMENT, Literal: "// last comment"},
 		}},
 	}, testutil.CompareLeadingTrivia(), testutil.CompareAfterNewline())
 }

--- a/scanner/scanners.go
+++ b/scanner/scanners.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"errors"
 	"strings"
 )
 
@@ -11,4 +12,50 @@ func ScanIdentifier(sc *Scanner) string {
 		sb.WriteRune(sc.currentChar)
 	}
 	return sb.String()
+}
+
+func ScanLineComment(sc *Scanner) string {
+	sb := strings.Builder{}
+	sb.WriteString("//")
+	for {
+		sc.AdvanceChar()
+		if sc.CurrentChar() == '\n' {
+			sb.WriteRune(sc.currentChar)
+			sc.AdvanceChar()
+			break
+		} else if sc.currentChar == '\r' {
+			sb.WriteRune(sc.currentChar)
+			sc.AdvanceChar()
+			if sc.CurrentChar() == '\n' {
+				sb.WriteRune(sc.currentChar)
+				sc.AdvanceChar()
+			}
+			break
+		} else if sc.CurrentChar() == EOF {
+			break
+		}
+		sb.WriteRune(sc.CurrentChar())
+	}
+	return sb.String()
+}
+
+func ScanBlockComment(sc *Scanner) (string, error) {
+	sb := strings.Builder{}
+	sb.WriteString("/*")
+	sc.AdvanceChar() // consume "*"
+	for {
+		if sc.currentChar == '*' && sc.PeekChar() == '/' {
+			// consume "*/"
+			for range 2 {
+				sb.WriteRune(sc.currentChar)
+				sc.AdvanceChar()
+			}
+			break
+		} else if sc.currentChar == EOF {
+			return sb.String(), errors.New("unexpected end of file")
+		}
+		sb.WriteRune(sc.currentChar)
+		sc.AdvanceChar()
+	}
+	return sb.String(), nil
 }

--- a/token/token.go
+++ b/token/token.go
@@ -80,7 +80,9 @@ const (
 	RBRACKET  // ]
 	NEWLINE   // \r, \n, \r\n
 	// others
-	DIGIT // 0..9
+	DIGIT         // 0..9
+	LINE_COMMENT  // // ..
+	BLOCK_COMMENT // /* .. */
 )
 
 var tokenLiterals = map[Type]string{
@@ -124,7 +126,9 @@ var tokenLiterals = map[Type]string{
 	RBRACKET:  "]",
 	NEWLINE:   "new line",
 	// others
-	DIGIT: "digit",
+	DIGIT:         "digit",
+	LINE_COMMENT:  "line comment",
+	BLOCK_COMMENT: "block comment",
 }
 
 const initCustomType Type = 1000

--- a/xjs.go
+++ b/xjs.go
@@ -62,18 +62,6 @@ func PluginBuilder() *plugin.Builder {
 					}
 				}
 				tok.Literal += lit
-			case token.DIVIDE:
-				switch sc.CurrentChar() {
-				case '/':
-					tok.Type = js.LINE_COMMENT
-					tok.Literal = js.ScanLineComment(sc)
-				case '*':
-					tok.Type = js.BLOCK_COMMENT
-					if tok.Literal, err = js.ScanBlockComment(sc); err != nil {
-						tok.Type = token.ILLEGAL
-						return
-					}
-				}
 			case token.IDENT:
 				switch tok.Literal {
 				case "function":


### PR DESCRIPTION
This PR introduces a breaking API change.