### PR TITLE
refactor(parser): rename ExpectString to ExpectLiteral

### DIFF
--- a/js/stmt_import.go
+++ b/js/stmt_import.go
@@ -52,7 +52,7 @@ func ParseImportStmt(p *parser.Parser) (node *ImportStmt, err error) {
 			// import * as lib from 'lib.js'
 			node.Layout.Multiply = p.CurrentToken
 			p.AdvanceToken()
-			if node.Layout.As, err = p.ExpectString("as"); err != nil {
+			if node.Layout.As, err = p.ExpectLiteral("as"); err != nil {
 				return
 			}
 			if node.Namespace, err = ParseIdent(p); err != nil {
@@ -94,7 +94,7 @@ func ParseImportStmt(p *parser.Parser) (node *ImportStmt, err error) {
 			err = p.Error("syntax error")
 			return
 		}
-		if node.Layout.From, err = p.ExpectString("from"); err != nil {
+		if node.Layout.From, err = p.ExpectLiteral("from"); err != nil {
 			return
 		}
 		if node.Path, err = p.Expect(token.STRING); err != nil {

--- a/jsextended/stmt_forin.go
+++ b/jsextended/stmt_forin.go
@@ -47,7 +47,7 @@ func ParseForinStmt(p *parser.Parser) (node *ForinStmt, err error) {
 	if err != nil {
 		return
 	}
-	if node.Layout.In, err = p.ExpectString("in"); err != nil {
+	if node.Layout.In, err = p.ExpectLiteral("in"); err != nil {
 		return
 	}
 	if node.Value, err = p.ParseExpr(); err != nil {

--- a/jsextended/stmt_forof.go
+++ b/jsextended/stmt_forof.go
@@ -47,7 +47,7 @@ func ParseForofStmt(p *parser.Parser) (node *ForofStmt, err error) {
 	if err != nil {
 		return
 	}
-	if node.Layout.Of, err = p.ExpectString("of"); err != nil {
+	if node.Layout.Of, err = p.ExpectLiteral("of"); err != nil {
 		return
 	}
 	if node.Value, err = p.ParseExpr(); err != nil {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -128,7 +128,7 @@ func (p *Parser) Expect(typ token.Type) (token.Token, error) {
 	return tok, nil
 }
 
-func (p *Parser) ExpectString(s string) (token.Token, error) {
+func (p *Parser) ExpectLiteral(s string) (token.Token, error) {
 	tok := p.CurrentToken
 	if tok.Literal != s {
 		return tok, p.Error(s + " expected")

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -68,7 +68,7 @@ func TestMain(m *testing.M) {
 func TestLookahead(t *testing.T) {
 	parser1 := func(p *parser.Parser) (node *js.Variable, err error) {
 		node = &js.Variable{}
-		if node.Token, err = p.ExpectString("a"); err != nil {
+		if node.Token, err = p.ExpectLiteral("a"); err != nil {
 			return
 		}
 		return
@@ -76,7 +76,7 @@ func TestLookahead(t *testing.T) {
 
 	parser2 := func(p *parser.Parser) (node *js.Variable, err error) {
 		node = &js.Variable{}
-		if node.Token, err = p.ExpectString("b"); err != nil {
+		if node.Token, err = p.ExpectLiteral("b"); err != nil {
 			return
 		}
 		return


### PR DESCRIPTION
This PR introduces a breaking API change.