### PR TITLE
refactor: remove xjs.Parse and xjs.Print

### DIFF
--- a/examples/xjscli/main.go
+++ b/examples/xjscli/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/xjslang/xjs"
+	"github.com/xjslang/xjs/internal"
 )
 
 func usage() {
@@ -66,7 +67,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	program, err := xjs.Parse(data)
+	program, err := internal.Parse(data)
 
 	// prints errors
 	if checkFlag {

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -1,0 +1,20 @@
+package internal
+
+import (
+	"github.com/xjslang/xjs"
+	"github.com/xjslang/xjs/ast"
+	"github.com/xjslang/xjs/js"
+	"github.com/xjslang/xjs/printer"
+)
+
+func Parse(input []byte) (*js.Program, error) {
+	sc := xjs.ScannerBuilder().Build(input)
+	p := xjs.ParserBuilder().Build(sc)
+	return js.ParseProgram(p)
+}
+
+func Print(result ast.Node, opts ...printer.Option) (string, error) {
+	pr := xjs.PrinterBuilder().Build(opts...)
+	pr.Print(result)
+	return pr.Output()
+}

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/xjslang/xjs"
 	"github.com/xjslang/xjs/internal"
 	"github.com/xjslang/xjs/parser"
 	"github.com/xorcare/golden"
@@ -24,11 +23,11 @@ func TestRoundtripFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			result, err := xjs.Parse(data)
+			result, err := internal.Parse(data)
 			require.NoError(t, err)
 
 			// AST -> code
-			code, err := xjs.Print(result)
+			code, err := internal.Print(result)
 			require.NoError(t, err)
 
 			assert.Equal(t, string(data), code)
@@ -46,7 +45,7 @@ func TestDebugFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			result, err := xjs.Parse(data)
+			result, err := internal.Parse(data)
 			require.NoError(t, err)
 
 			// AST -> code
@@ -68,15 +67,15 @@ func TestCheckFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			result, err := xjs.Parse(data)
+			result, err := internal.Parse(data)
 			require.NoError(t, err)
 
 			// AST -> code
-			code, err := xjs.Print(result)
+			code, err := internal.Print(result)
 			require.NoError(t, err)
 
 			// verify printed code parses
-			_, err = xjs.Parse([]byte(code))
+			_, err = internal.Parse([]byte(code))
 			require.NoError(t, err)
 		})
 	}
@@ -92,7 +91,7 @@ func TestErrorFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			_, errs := xjs.Parse(data)
+			_, errs := internal.Parse(data)
 			require.Error(t, errs)
 			require.IsType(t, parser.ErrorList{}, errs)
 

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/xjslang/xjs"
 	"github.com/xjslang/xjs/ast"
+	"github.com/xjslang/xjs/internal"
 	"github.com/xjslang/xjs/js"
 	"github.com/xjslang/xjs/parser"
 	"github.com/xjslang/xjs/printer"
@@ -129,7 +130,7 @@ func TestPrintInfixParenOp(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("exp %d", i), func(t *testing.T) {
-			node, err := xjs.Parse([]byte(test.input))
+			node, err := internal.Parse([]byte(test.input))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -165,7 +166,7 @@ func TestLastComment(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			node, err := xjs.Parse([]byte(test.input))
+			node, err := internal.Parse([]byte(test.input))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -391,7 +392,7 @@ func TestWithComments(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := xjs.Parse([]byte(input))
+			result, err := internal.Parse([]byte(input))
 			require.NoError(t, err)
 			test.pr.Print(result)
 			out, err := test.pr.Output()
@@ -414,7 +415,7 @@ func TestWithNewLines(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := xjs.Parse([]byte(input))
+			result, err := internal.Parse([]byte(input))
 			require.NoError(t, err)
 			test.pr.Print(result)
 			out, err := test.pr.Output()
@@ -435,9 +436,9 @@ func TestCompact(t *testing.T) {
 	let x = 100
 	/* b */
 	let y = 200`
-	result, err := xjs.Parse([]byte(input))
+	result, err := internal.Parse([]byte(input))
 	require.NoError(t, err)
-	out, err := xjs.Print(result, printer.Compact())
+	out, err := internal.Print(result, printer.Compact())
 	require.NoError(t, err)
 	golden.Assert(t, []byte(out))
 }

--- a/xjs.go
+++ b/xjs.go
@@ -1,24 +1,11 @@
 package xjs
 
 import (
-	"github.com/xjslang/xjs/ast"
 	"github.com/xjslang/xjs/js"
 	"github.com/xjslang/xjs/parser"
 	"github.com/xjslang/xjs/printer"
 	"github.com/xjslang/xjs/scanner"
 )
-
-func Parse(input []byte) (*js.Program, error) {
-	sc := ScannerBuilder().Build(input)
-	p := ParserBuilder().Build(sc)
-	return js.ParseProgram(p)
-}
-
-func Print(result ast.Node, opts ...printer.Option) (string, error) {
-	pr := PrinterBuilder().Build(opts...)
-	pr.Print(result)
-	return pr.Output()
-}
 
 func ScannerBuilder() *scanner.Builder {
 	return js.ScannerBuilder()

--- a/xjs_test.go
+++ b/xjs_test.go
@@ -4,22 +4,32 @@ import (
 	"fmt"
 
 	"github.com/xjslang/xjs"
+	"github.com/xjslang/xjs/js"
 )
 
 func Example_basic() {
 	input := `function hello() {
-	let x = 100
-	let y = 200
-}`
-	result, err := xjs.Parse([]byte(input))
+		let x = 100
+		let y = 200
+		}`
+
+	// code --> AST
+	sc := xjs.ScannerBuilder().Build([]byte(input))
+	p := xjs.ParserBuilder().Build(sc)
+	result, err := js.ParseProgram(p)
 	if err != nil {
 		panic(err)
 	}
-	out, err := xjs.Print(result)
+
+	// AST --> code
+	pr := xjs.PrinterBuilder().Build()
+	pr.Print(result)
+	out, err := pr.Output()
 	if err != nil {
 		panic(err)
 	}
 	fmt.Print(out)
+
 	// Output:
 	// function hello() {
 	//   let x = 100;


### PR DESCRIPTION
since xjs is a library for creating JavaScript dialects, not for parsing or printing JavaScript. Thos functions had no useful utility for the final user.