### PR TITLE
perf(scanner): eliminate closure allocation in middleware chain

### DIFF
--- a/examples/jsx/jsx.go
+++ b/examples/jsx/jsx.go
@@ -63,8 +63,8 @@ func parseTag(p *parser.Parser) (_ *Tag, err error) {
 	return node, nil
 }
 
-func jsxScanner(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-	if tok, err = next(); err != nil {
+func jsxScanner(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+	if tok, err = next(sc); err != nil {
 		return
 	}
 	if tok.Type == token.LT {

--- a/js/js.go
+++ b/js/js.go
@@ -31,8 +31,8 @@ var DEFAULT = token.RegisterType("DEFAULT", "default")
 // ScannerBuilder extends the simplified JavaScript scanner, allowing the input text to be split into custom tokens.
 func ScannerBuilder() *scanner.Builder {
 	sb := &scanner.Builder{}
-	sb.UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-		if tok, err = next(); err != nil {
+	sb.UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+		if tok, err = next(sc); err != nil {
 			return
 		}
 		if tok.Type == token.IDENT {

--- a/jsextended/jsextended.go
+++ b/jsextended/jsextended.go
@@ -51,8 +51,8 @@ var (
 
 func ScannerBuilder() *scanner.Builder {
 	sb := js.ScannerBuilder()
-	sb.UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-		if tok, err = next(); err != nil {
+	sb.UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+		if tok, err = next(sc); err != nil {
 			return
 		}
 		switch tok.Type {

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -448,8 +448,8 @@ func TestErrorAt(t *testing.T) {
 	token.RegisterPrefixOp(spreadOp)
 
 	sb := xjs.ScannerBuilder()
-	sb.UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-		if tok, err = next(); err != nil {
+	sb.UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+		if tok, err = next(sc); err != nil {
 			return
 		}
 		// instruct the scanner to recognize the spread operator
@@ -515,8 +515,8 @@ func TestPrinterContext(t *testing.T) {
 	awaitTyp := token.RegisterType("AWAIT", "await")
 
 	sb := xjs.ScannerBuilder()
-	sb.UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-		if tok, err = next(); err != nil {
+	sb.UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+		if tok, err = next(sc); err != nil {
 			return
 		}
 		if tok.Type == token.IDENT {

--- a/scanner/builder.go
+++ b/scanner/builder.go
@@ -3,10 +3,11 @@ package scanner
 import "github.com/xjslang/xjs/token"
 
 type Builder struct {
-	scanners []func(*Scanner, func() (token.Token, error)) (token.Token, error)
+	scanners []func(*Scanner, func(*Scanner) (token.Token, error)) (token.Token, error)
 }
 
-func (b *Builder) UseScanner(scanner func(sc *Scanner, next func() (token.Token, error)) (token.Token, error)) *Builder {
+// TODO: The middleware function type is repeated inline in both the Builder field and UseScanner signature, which makes the exported API harder to read and leads to long, duplicated types across the repo. Consider introducing named function types (e.g., NextScannerFunc / ScannerMiddleware) and using them in Builder/UseScanner (and in Scanner.useScanner) to keep signatures concise and consistent.
+func (b *Builder) UseScanner(scanner func(sc *Scanner, next func(*Scanner) (token.Token, error)) (token.Token, error)) *Builder {
 	b.scanners = append(b.scanners, scanner)
 	return b
 }

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -6,15 +6,14 @@ import (
 	"github.com/xjslang/xjs/token"
 )
 
-func (s *Scanner) useScanner(scanner func(s *Scanner, next func() (token.Token, error)) (token.Token, error)) {
+// TODO: In the parameter type for `scanner`, the argument is named `s *Scanner`, which is easy to confuse with the method receiver `s *Scanner`. Renaming it to `sc` (or omitting parameter names in the func type) improves readability without changing the type.
+func (s *Scanner) useScanner(scanner func(s *Scanner, next func(*Scanner) (token.Token, error)) (token.Token, error)) {
 	next := s.scanner
 	if next == nil {
 		next = defaultScanner
 	}
 	s.scanner = func(s *Scanner) (token.Token, error) {
-		return scanner(s, func() (token.Token, error) {
-			return next(s)
-		})
+		return scanner(s, next)
 	}
 }
 

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -100,19 +100,19 @@ func ExampleBuilder_Build() {
 	caretType := token.RegisterType("CARET", "^")
 	sb := scanner.Builder{}
 	s := sb.
-		UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (token.Token, error) {
+		UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (token.Token, error) {
 			if sc.CurrentChar() == '#' {
 				sc.AdvanceChar()
 				return token.Token{Type: hashTyp, Literal: "#"}, nil
 			}
-			return next() // Delegate to the "next" middleware
+			return next(sc) // Delegate to the "next" middleware
 		}).
-		UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (token.Token, error) {
+		UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (token.Token, error) {
 			if sc.CurrentChar() == '^' {
 				sc.AdvanceChar()
 				return token.Token{Type: caretType, Literal: "^"}, nil
 			}
-			return next() // Delegate to the "next" middleware
+			return next(sc) // Delegate to the "next" middleware
 		}).
 		Build([]byte("#some ^input"))
 
@@ -137,8 +137,8 @@ func BenchmarkUseScanner(b *testing.B) {
 
 	sb := scanner.Builder{}
 	for range 10 {
-		sb.UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-			if tok, err = next(); err != nil {
+		sb.UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+			if tok, err = next(sc); err != nil {
 				return
 			}
 			return
@@ -498,14 +498,14 @@ func TestUseScanner(t *testing.T) {
 	powType := token.RegisterType("POW", "**")
 	sb := scanner.Builder{}
 	sc := sb.
-		UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (token.Token, error) {
+		UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (token.Token, error) {
 			if sc.CurrentChar() == '*' && sc.PeekChar() == '*' {
 				// consume **
 				sc.AdvanceChar()
 				sc.AdvanceChar()
 				return token.Token{Type: powType, Literal: powType.Literal()}, nil
 			}
-			return next()
+			return next(sc)
 		}).
 		Build([]byte("5 ** 2"))
 	assertLexerTokens(t, sc, []token.Token{

--- a/xjs_infixop_test.go
+++ b/xjs_infixop_test.go
@@ -27,8 +27,8 @@ func Example_infixOp_pipeline() {
 
 	// Create a scanner that recognize the "|>" token.
 	sb := jsextended.ScannerBuilder()
-	sb.UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-		if tok, err = next(); err != nil {
+	sb.UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+		if tok, err = next(sc); err != nil {
 			return
 		}
 		if tok.Literal == "|" && sc.CurrentChar() == '>' {

--- a/xjs_prefixop_test.go
+++ b/xjs_prefixop_test.go
@@ -26,8 +26,8 @@ type PrefixTagOp struct {
 }
 
 // "Teach" the scanner how to recognize our custom tokens.
-func htmlScanner(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-	if tok, err = next(); err != nil {
+func htmlScanner(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+	if tok, err = next(sc); err != nil {
 		return
 	}
 	switch tok.Type {

--- a/xjs_stmt_test.go
+++ b/xjs_stmt_test.go
@@ -25,8 +25,8 @@ type DeferStmt struct {
 func Example_stmt_defer() {
 	// Create a scanner that recognizes the "defer" token.
 	sb := xjs.ScannerBuilder()
-	sb.UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-		if tok, err = next(); err != nil {
+	sb.UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+		if tok, err = next(sc); err != nil {
 			return
 		}
 		if tok.Literal == "defer" {

--- a/xjs_test.go
+++ b/xjs_test.go
@@ -14,8 +14,8 @@ func ExampleScannerBuilder() {
 	notLikeTyp := token.RegisterType("NOT_LIKE", "~!")
 
 	sb := xjs.ScannerBuilder()
-	sb.UseScanner(func(sc *scanner.Scanner, next func() (token.Token, error)) (tok token.Token, err error) {
-		if tok, err = next(); err != nil {
+	sb.UseScanner(func(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, error)) (tok token.Token, err error) {
+		if tok, err = next(sc); err != nil {
 			return
 		}
 		if tok.Literal == "~" {


### PR DESCRIPTION
This PR introduces a breaking API change.

**How to reproduce**
```bash
git checkout main
go test -bench=BenchmarkUseScanner -benchmem -count=10 ./scanner/... > before.out

git checkout perf/eliminate-closure-allocation-in-middleware-chain
go test -bench=BenchmarkUseScanner -benchmem -count=10 ./scanner/... > after.out

benchstat before.out after.out
```

**Results** (Apple M1 Pro, Go 1.26.2):
```
goos: darwin
goarch: arm64
pkg: github.com/xjslang/xjs/scanner
cpu: Apple M1 Pro
             │  before.out  │              after.out              │
             │    sec/op    │   sec/op     vs base                │
UseScanner-8   13.624m ± 4%   6.395m ± 3%  -53.06% (p=0.000 n=10)

             │  before.out   │              after.out               │
             │     B/op      │     B/op      vs base                │
UseScanner-8   8410.6Ki ± 0%   838.4Ki ± 0%  -90.03% (p=0.000 n=10)

             │  before.out  │              after.out              │
             │  allocs/op   │  allocs/op   vs base                │
UseScanner-8   361.72k ± 0%   38.64k ± 0%  -89.32% (p=0.000 n=10)
```