### PR TITLE
perf(parser): eliminate closure allocation in middleware chain

### DIFF
--- a/examples/jsx/jsx.go
+++ b/examples/jsx/jsx.go
@@ -83,14 +83,14 @@ func jsxScanner(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, e
 	return
 }
 
-func jsxPrefixOpParser(p *parser.Parser, next func() (ast.Expr, error)) (_ ast.Expr, err error) {
+func jsxPrefixOpParser(p *parser.Parser, next func(*parser.Parser) (ast.Expr, error)) (_ ast.Expr, err error) {
 	if p.CurrentToken.Type == startTag {
 		return parseTag(p)
 	}
-	return next()
+	return next(p)
 }
 
-func jsxInfixOpParser(p *parser.Parser, left ast.Expr, next func(left ast.Expr) (ast.Expr, error)) (_ ast.Expr, err error) {
+func jsxInfixOpParser(p *parser.Parser, left ast.Expr, next func(*parser.Parser, ast.Expr) (ast.Expr, error)) (_ ast.Expr, err error) {
 	if p.CurrentToken.Type == concatTag {
 		node := &ConcatExpr{Left: left}
 		p.AdvanceToken()
@@ -99,7 +99,7 @@ func jsxInfixOpParser(p *parser.Parser, left ast.Expr, next func(left ast.Expr) 
 		}
 		return node, nil
 	}
-	return next(left)
+	return next(p, left)
 }
 
 func Parse(input []byte) (*js.Program, error) {

--- a/js/js.go
+++ b/js/js.go
@@ -76,7 +76,7 @@ func ParserBuilder() *parser.Builder {
 	token.RegisterPrefixOp(DELETE)
 
 	pb := &parser.Builder{}
-	pb.UseStmtParser(func(p *parser.Parser, next func() (ast.Stmt, error)) (ast.Stmt, error) {
+	pb.UseStmtParser(func(p *parser.Parser, next func(*parser.Parser) (ast.Stmt, error)) (ast.Stmt, error) {
 		switch p.CurrentToken.Type {
 		case FUNCTION:
 			return ParseFunctionDecl(p)
@@ -108,10 +108,10 @@ func ParserBuilder() *parser.Builder {
 		}
 		return ParseStmt(p)
 	})
-	pb.UseExprParser(func(p *parser.Parser, next func() (ast.Expr, error)) (ast.Expr, error) {
+	pb.UseExprParser(func(p *parser.Parser, next func(*parser.Parser) (ast.Expr, error)) (ast.Expr, error) {
 		return ParseExpr(p)
 	})
-	pb.UsePrefixOpParser(func(p *parser.Parser, next func() (ast.Expr, error)) (ast.Expr, error) {
+	pb.UsePrefixOpParser(func(p *parser.Parser, next func(*parser.Parser) (ast.Expr, error)) (ast.Expr, error) {
 		switch p.CurrentToken.Type {
 		case FUNCTION:
 			return ParsePrefixFunctionOp(p)
@@ -126,7 +126,7 @@ func ParserBuilder() *parser.Builder {
 		}
 		return ParsePrefixOp(p)
 	})
-	pb.UseInfixOpParser(func(p *parser.Parser, left ast.Expr, next func(left ast.Expr) (ast.Expr, error)) (ast.Expr, error) {
+	pb.UseInfixOpParser(func(p *parser.Parser, left ast.Expr, next func(*parser.Parser, ast.Expr) (ast.Expr, error)) (ast.Expr, error) {
 		switch p.CurrentToken.Type {
 		case token.ASSIGN:
 			return ParseInfixAssignOp(p, left)

--- a/jsextended/jsextended.go
+++ b/jsextended/jsextended.go
@@ -292,7 +292,7 @@ func ParserBuilder() *parser.Builder {
 	token.RegisterInfixOp(token.STRING, token.LPAREN.Precedence())
 
 	pb := js.ParserBuilder()
-	pb.UsePrefixOpParser(func(p *parser.Parser, next func() (ast.Expr, error)) (ast.Expr, error) {
+	pb.UsePrefixOpParser(func(p *parser.Parser, next func(*parser.Parser) (ast.Expr, error)) (ast.Expr, error) {
 		switch p.CurrentToken.Type {
 		case token.LPAREN:
 			return ParsePrefixParenOp(p)
@@ -323,9 +323,9 @@ func ParserBuilder() *parser.Builder {
 		case YIELD:
 			return ParsePrefixYieldOp(p)
 		}
-		return next()
+		return next(p)
 	})
-	pb.UseInfixOpParser(func(p *parser.Parser, left ast.Expr, next func(left ast.Expr) (ast.Expr, error)) (ast.Expr, error) {
+	pb.UseInfixOpParser(func(p *parser.Parser, left ast.Expr, next func(*parser.Parser, ast.Expr) (ast.Expr, error)) (ast.Expr, error) {
 		switch p.CurrentToken.Type {
 		case STRICT_EQ, STRICT_NOT_EQ, PLUS_ASSIGN, MINUS_ASSIGN, MULTIPLY_ASSIGN, DIVIDE_ASSIGN, MODULO_ASSIGN, OR_ASSIGN, XOR_ASSIGN, AND_ASSIGN, EXPO_ASSIGN, IN:
 			return js.ParseInfixOp(p, left)
@@ -344,9 +344,9 @@ func ParserBuilder() *parser.Builder {
 		case token.STRING:
 			return ParseInfixTemplateOp(p, left)
 		}
-		return next(left)
+		return next(p, left)
 	})
-	pb.UseStmtParser(func(p *parser.Parser, next func() (ast.Stmt, error)) (ast.Stmt, error) {
+	pb.UseStmtParser(func(p *parser.Parser, next func(*parser.Parser) (ast.Stmt, error)) (ast.Stmt, error) {
 		switch p.CurrentToken.Type {
 		case js.LET, CONST, VAR:
 			return ParseVarStmt(p)
@@ -371,7 +371,7 @@ func ParserBuilder() *parser.Builder {
 		case CLASS:
 			return ParseClassStmt(p)
 		}
-		return next()
+		return next(p)
 	})
 	return pb
 }

--- a/parser/builder.go
+++ b/parser/builder.go
@@ -6,28 +6,28 @@ import (
 )
 
 type Builder struct {
-	stmtParsers     []func(*Parser, func() (ast.Stmt, error)) (ast.Stmt, error)
-	exprParsers     []func(*Parser, func() (ast.Expr, error)) (ast.Expr, error)
-	prefixOpParsers []func(*Parser, func() (ast.Expr, error)) (ast.Expr, error)
-	infixOpParsers  []func(*Parser, ast.Expr, func(ast.Expr) (ast.Expr, error)) (ast.Expr, error)
+	stmtParsers     []func(*Parser, func(*Parser) (ast.Stmt, error)) (ast.Stmt, error)
+	exprParsers     []func(*Parser, func(*Parser) (ast.Expr, error)) (ast.Expr, error)
+	prefixOpParsers []func(*Parser, func(*Parser) (ast.Expr, error)) (ast.Expr, error)
+	infixOpParsers  []func(*Parser, ast.Expr, func(*Parser, ast.Expr) (ast.Expr, error)) (ast.Expr, error)
 }
 
-func (b *Builder) UseStmtParser(parser func(p *Parser, next func() (ast.Stmt, error)) (ast.Stmt, error)) *Builder {
+func (b *Builder) UseStmtParser(parser func(p *Parser, next func(*Parser) (ast.Stmt, error)) (ast.Stmt, error)) *Builder {
 	b.stmtParsers = append(b.stmtParsers, parser)
 	return b
 }
 
-func (b *Builder) UseExprParser(parser func(p *Parser, next func() (ast.Expr, error)) (ast.Expr, error)) *Builder {
+func (b *Builder) UseExprParser(parser func(p *Parser, next func(*Parser) (ast.Expr, error)) (ast.Expr, error)) *Builder {
 	b.exprParsers = append(b.exprParsers, parser)
 	return b
 }
 
-func (b *Builder) UsePrefixOpParser(parser func(p *Parser, next func() (ast.Expr, error)) (ast.Expr, error)) *Builder {
+func (b *Builder) UsePrefixOpParser(parser func(p *Parser, next func(*Parser) (ast.Expr, error)) (ast.Expr, error)) *Builder {
 	b.prefixOpParsers = append(b.prefixOpParsers, parser)
 	return b
 }
 
-func (b *Builder) UseInfixOpParser(parser func(p *Parser, left ast.Expr, next func(left ast.Expr) (ast.Expr, error)) (ast.Expr, error)) *Builder {
+func (b *Builder) UseInfixOpParser(parser func(p *Parser, left ast.Expr, next func(*Parser, ast.Expr) (ast.Expr, error)) (ast.Expr, error)) *Builder {
 	b.infixOpParsers = append(b.infixOpParsers, parser)
 	return b
 }

--- a/parser/middleware.go
+++ b/parser/middleware.go
@@ -4,51 +4,43 @@ import (
 	"github.com/xjslang/xjs/ast"
 )
 
-func (p *Parser) usePrefixOpParser(parser func(p *Parser, next func() (ast.Expr, error)) (ast.Expr, error)) {
+func (p *Parser) usePrefixOpParser(parser func(p *Parser, next func(*Parser) (ast.Expr, error)) (ast.Expr, error)) {
 	next := p.prefixOpParser
 	if next == nil {
 		next = defaultPrefixOpParser
 	}
 	p.prefixOpParser = func(p *Parser) (ast.Expr, error) {
-		return parser(p, func() (ast.Expr, error) {
-			return next(p)
-		})
+		return parser(p, next)
 	}
 }
 
-func (p *Parser) useInfixOpParser(parser func(p *Parser, left ast.Expr, next func(left ast.Expr) (ast.Expr, error)) (ast.Expr, error)) {
+func (p *Parser) useInfixOpParser(parser func(p *Parser, left ast.Expr, next func(*Parser, ast.Expr) (ast.Expr, error)) (ast.Expr, error)) {
 	next := p.infixOpParser
 	if next == nil {
 		next = infixOpParser
 	}
 	p.infixOpParser = func(p *Parser, left ast.Expr) (ast.Expr, error) {
-		return parser(p, left, func(left ast.Expr) (ast.Expr, error) {
-			return next(p, left)
-		})
+		return parser(p, left, next)
 	}
 }
 
-func (p *Parser) useStmtParser(parser func(p *Parser, next func() (ast.Stmt, error)) (ast.Stmt, error)) {
+func (p *Parser) useStmtParser(parser func(p *Parser, next func(*Parser) (ast.Stmt, error)) (ast.Stmt, error)) {
 	next := p.stmtParser
 	if next == nil {
 		next = defaultStmtParser
 	}
 	p.stmtParser = func(p *Parser) (ast.Stmt, error) {
-		return parser(p, func() (ast.Stmt, error) {
-			return next(p)
-		})
+		return parser(p, next)
 	}
 }
 
-func (p *Parser) useExprParser(parser func(p *Parser, next func() (ast.Expr, error)) (ast.Expr, error)) {
+func (p *Parser) useExprParser(parser func(p *Parser, next func(*Parser) (ast.Expr, error)) (ast.Expr, error)) {
 	next := p.exprParser
 	if next == nil {
 		next = defaultExprParser
 	}
 	p.exprParser = func(p *Parser) (ast.Expr, error) {
-		return parser(p, func() (ast.Expr, error) {
-			return next(p)
-		})
+		return parser(p, next)
 	}
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -32,7 +32,7 @@ func ExampleBuilder_Build() {
 	s := sb.Build([]byte("print('Hello, World!')"))
 	pb := parser.Builder{}
 	p := pb.
-		UseStmtParser(func(p *parser.Parser, next func() (ast.Stmt, error)) (_ ast.Stmt, err error) {
+		UseStmtParser(func(p *parser.Parser, next func(*parser.Parser) (ast.Stmt, error)) (_ ast.Stmt, err error) {
 			if p.CurrentToken.Type == token.IDENT && p.CurrentToken.Literal == "print" {
 				p.AdvanceToken()
 				node := &MyCustomStmt{}
@@ -47,7 +47,7 @@ func ExampleBuilder_Build() {
 				}
 				return node, nil
 			}
-			return next() // Delegate to the "next" middleware
+			return next(p) // Delegate to the "next" middleware
 		}).
 		Build(s)
 

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -531,7 +531,7 @@ func TestPrinterContext(t *testing.T) {
 	})
 
 	pb := xjs.ParserBuilder()
-	pb.UseStmtParser(func(p *parser.Parser, next func() (ast.Stmt, error)) (_ ast.Stmt, err error) {
+	pb.UseStmtParser(func(p *parser.Parser, next func(*parser.Parser) (ast.Stmt, error)) (_ ast.Stmt, err error) {
 		switch p.CurrentToken.Type {
 		case asyncTyp:
 			node := &AsyncFunctionDecl{}
@@ -550,7 +550,7 @@ func TestPrinterContext(t *testing.T) {
 			}
 			return node, nil
 		}
-		return next()
+		return next(p)
 	})
 
 	input := `function fetchUserData() {

--- a/xjs_infixop_test.go
+++ b/xjs_infixop_test.go
@@ -41,9 +41,9 @@ func Example_infixOp_pipeline() {
 
 	// Create a parser that "understand" the pipeline syntax.
 	pb := jsextended.ParserBuilder()
-	pb.UseInfixOpParser(func(p *parser.Parser, left ast.Expr, next func(left ast.Expr) (ast.Expr, error)) (_ ast.Expr, err error) {
+	pb.UseInfixOpParser(func(p *parser.Parser, left ast.Expr, next func(*parser.Parser, ast.Expr) (ast.Expr, error)) (_ ast.Expr, err error) {
 		if p.CurrentToken.Type != PIPE {
-			return next(left) // delegate to the "next" middleware
+			return next(p, left) // delegate to the "next" middleware
 		}
 		p.AdvanceToken()
 		node := &InfixPipeOp{Left: left}

--- a/xjs_postfixop_test.go
+++ b/xjs_postfixop_test.go
@@ -26,9 +26,9 @@ func Example_postfixOp_factorial() {
 
 	// Create a parser that recognizes the factorial syntax.
 	pb := xjs.ParserBuilder()
-	pb.UseInfixOpParser(func(p *parser.Parser, left ast.Expr, next func(left ast.Expr) (ast.Expr, error)) (_ ast.Expr, err error) {
+	pb.UseInfixOpParser(func(p *parser.Parser, left ast.Expr, next func(*parser.Parser, ast.Expr) (ast.Expr, error)) (_ ast.Expr, err error) {
 		if p.CurrentToken.Type != token.NOT {
-			return next(left)
+			return next(p, left)
 		}
 		p.AdvanceToken()
 		node := &PostfixFactorialOp{Value: left}

--- a/xjs_prefixop_test.go
+++ b/xjs_prefixop_test.go
@@ -46,9 +46,9 @@ func htmlScanner(sc *scanner.Scanner, next func(*scanner.Scanner) (token.Token, 
 }
 
 // "Teach" the parser how to traverse our custom syntax.
-func htmlPrefixParser(p *parser.Parser, next func() (ast.Expr, error)) (_ ast.Expr, err error) {
+func htmlPrefixParser(p *parser.Parser, next func(*parser.Parser) (ast.Expr, error)) (_ ast.Expr, err error) {
 	if p.CurrentToken.Type != START_TAG {
-		return next() // delegate to the "next" parser
+		return next(p) // delegate to the "next" parser
 	}
 	node := &PrefixTagOp{}
 	if _, err = p.Expect(START_TAG); err != nil {

--- a/xjs_stmt_test.go
+++ b/xjs_stmt_test.go
@@ -37,9 +37,9 @@ func Example_stmt_defer() {
 
 	// Create a parser that "understand" the defer syntax.
 	pb := xjs.ParserBuilder()
-	pb.UseStmtParser(func(p *parser.Parser, next func() (ast.Stmt, error)) (node ast.Stmt, err error) {
+	pb.UseStmtParser(func(p *parser.Parser, next func(*parser.Parser) (ast.Stmt, error)) (node ast.Stmt, err error) {
 		if p.CurrentToken.Type != DEFER {
-			return next() // delegate to the "next" middleware
+			return next(p) // delegate to the "next" middleware
 		}
 		deferStmt := &DeferStmt{Defer: p.CurrentToken}
 		p.AdvanceToken() // consume "defer"


### PR DESCRIPTION
This PR introduces a breaking API change.

**How to reproduce**
```bash
git checkout main
go test -bench="^BenchmarkParse$" -benchmem -count=10 ./jsextended/... > before.out

git checkout perf/eliminate-closure-allocation-in-middleware-chain
go test -bench="^BenchmarkParse$" -benchmem -count=10 ./jsextended/... > after.out

benchstat before.out after.out
```
**Results** (Apple M1 Pro, Go 1.26.2):
```
goos: darwin
goarch: arm64
pkg: github.com/xjslang/xjs/jsextended
cpu: Apple M1 Pro
        │ before.out  │             after.out              │
        │   sec/op    │   sec/op     vs base               │
Parse-8   6.591m ± 2%   6.250m ± 3%  -5.18% (p=0.000 n=10)

        │  before.out  │              after.out               │
        │     B/op     │     B/op      vs base                │
Parse-8   4.782Mi ± 0%   4.298Mi ± 0%  -10.12% (p=0.000 n=10)

        │ before.out  │              after.out              │
        │  allocs/op  │  allocs/op   vs base                │
Parse-8   90.76k ± 0%   69.62k ± 0%  -23.29% (p=0.000 n=10)
```