### PR TITLE
perf(printer): eliminate closure allocation in middleware chain

### DIFF
--- a/examples/jsx/compiler.go
+++ b/examples/jsx/compiler.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Compiler transforms the code to valid JS code.
-func Compiler(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+func Compiler(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 	switch v := node.(type) {
 	case *ConcatExpr:
 		pr.Print("(function(){")
@@ -22,7 +22,7 @@ func Compiler(pr *printer.Printer, node ast.Node, next func(node ast.Node) error
 		}
 		pr.Print("return elem})()")
 	default:
-		return next(node)
+		return next(pr, node)
 	}
 	return nil
 }

--- a/examples/jsx/formatter.go
+++ b/examples/jsx/formatter.go
@@ -5,7 +5,7 @@ import (
 	"github.com/xjslang/xjs/printer"
 )
 
-func Formatter(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+func Formatter(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 	switch v := node.(type) {
 	case *ConcatExpr:
 		pr.Print(v.Left, " | ", v.Right)
@@ -18,7 +18,7 @@ func Formatter(pr *printer.Printer, node ast.Node, next func(node ast.Node) erro
 		pr.DecreaseIndent()
 		pr.Line().Print("</", v.Name, ">")
 	default:
-		return next(node)
+		return next(pr, node)
 	}
 	return nil
 }

--- a/internal/debug.go
+++ b/internal/debug.go
@@ -17,7 +17,7 @@ func Debug(node ast.Node) (string, error) {
 
 // adds parentheses around expressions to make operator precedence explicit
 // for debugging purposes
-func debugger(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+func debugger(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 	switch node.(type) {
 	case
 		// core expressions to parenthesize in debug output
@@ -28,5 +28,5 @@ func debugger(pr *printer.Printer, node ast.Node, next func(node ast.Node) error
 		pr.Print('(')
 		defer pr.Print(')')
 	}
-	return next(node)
+	return next(pr, node)
 }

--- a/js/js.go
+++ b/js/js.go
@@ -152,7 +152,7 @@ func ParserBuilder() *parser.Builder {
 // PrinterBuilder extends the simplified JavaScript printer, allowing custom language features to be printed.
 func PrinterBuilder() *printer.Builder {
 	pb := &printer.Builder{}
-	pb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+	pb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 		switch v := node.(type) {
 		case *Program:
 			return PrintProgram(pr, v)
@@ -221,7 +221,7 @@ func PrinterBuilder() *printer.Builder {
 		case *PrefixDeleteOp:
 			return PrintPrefixDeleteOp(pr, v)
 		}
-		return next(node)
+		return next(pr, node)
 	})
 	return pb
 }

--- a/jsextended/jsextended.go
+++ b/jsextended/jsextended.go
@@ -378,7 +378,7 @@ func ParserBuilder() *parser.Builder {
 
 func PrinterBuilder() *printer.Builder {
 	prb := js.PrinterBuilder()
-	prb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+	prb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 		switch v := node.(type) {
 		case *js.PrefixBracketOp:
 			return PrintPrefixBracketOp(pr, v)
@@ -439,7 +439,7 @@ func PrinterBuilder() *printer.Builder {
 		case *InfixTemplateOp:
 			return PrintInfixTemplateOp(pr, v)
 		}
-		return next(node)
+		return next(pr, node)
 	})
 	return prb
 }

--- a/printer/builder.go
+++ b/printer/builder.go
@@ -3,10 +3,10 @@ package printer
 import "github.com/xjslang/xjs/ast"
 
 type Builder struct {
-	printers []func(*Printer, ast.Node, func(ast.Node) error) error
+	printers []func(*Printer, ast.Node, func(*Printer, ast.Node) error) error
 }
 
-func (b *Builder) UsePrinter(printer func(pr *Printer, node ast.Node, next func(node ast.Node) error) error) *Builder {
+func (b *Builder) UsePrinter(printer func(pr *Printer, node ast.Node, next func(*Printer, ast.Node) error) error) *Builder {
 	b.printers = append(b.printers, printer)
 	return b
 }

--- a/printer/middleware.go
+++ b/printer/middleware.go
@@ -4,15 +4,13 @@ import (
 	"github.com/xjslang/xjs/ast"
 )
 
-func (pr *Printer) usePrinter(printer func(pr *Printer, node ast.Node, next func(node ast.Node) error) error) {
-	print := pr.printer
+func (pr *Printer) usePrinter(printer func(pr *Printer, node ast.Node, next func(*Printer, ast.Node) error) error) {
+	next := pr.printer
 	if pr.printer == nil {
-		print = defaultPrinter
+		next = defaultPrinter
 	}
 	pr.printer = func(p *Printer, node ast.Node) error {
-		return printer(p, node, func(node ast.Node) error {
-			return print(p, node)
-		})
+		return printer(p, node, next)
 	}
 }
 

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -24,12 +24,12 @@ type FactorialNode struct {
 func ExampleBuilder_Build() {
 	pb := printer.Builder{}
 	pr := pb.
-		UsePrinter(func(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+		UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 			if node, ok := node.(*FactorialNode); ok {
 				pr.Print(node.Value, "!")
 				return nil
 			}
-			return next(node) // delegate to the "next" middleware
+			return next(pr, node) // delegate to the "next" middleware
 		}).
 		Build()
 	pr.Print(&FactorialNode{Value: "125"})
@@ -277,12 +277,12 @@ type MyCustomStmt struct {
 func TestBeside(t *testing.T) {
 	pb := printer.Builder{}
 	pr := pb.
-		UsePrinter(func(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+		UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 			if v, ok := node.(*MyCustomStmt); ok {
 				pr.Line().Print(v.name)
 				return nil
 			}
-			return next(node)
+			return next(pr, node)
 		}).
 		Build()
 	pr.Print("aaa")
@@ -464,14 +464,14 @@ func TestErrorAt(t *testing.T) {
 		return
 	})
 
-	pr := xjs.PrinterBuilder().UsePrinter(func(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+	pr := xjs.PrinterBuilder().UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 		switch v := node.(type) {
 		case *js.PrefixOp:
 			if v.Op.Type == spreadOp {
 				return printer.ErrorAt(v.Op.Position, "spread operator is not printable")
 			}
 		}
-		return next(node)
+		return next(pr, node)
 	}).Build()
 
 	input := `let x = ..rest`
@@ -562,7 +562,7 @@ func TestPrinterContext(t *testing.T) {
 	require.NoError(t, err)
 
 	pr := xjs.PrinterBuilder().
-		UsePrinter(func(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+		UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 			switch v := node.(type) {
 			case *AsyncFunctionDecl:
 				ctx := pr.PushContext()
@@ -581,7 +581,7 @@ func TestPrinterContext(t *testing.T) {
 				pr.Space().Print(v.Expr)
 				return nil
 			}
-			return next(node)
+			return next(pr, node)
 		}).
 		Build()
 	pr.Print(result)

--- a/xjs_infixop_test.go
+++ b/xjs_infixop_test.go
@@ -57,7 +57,7 @@ func Example_infixOp_pipeline() {
 
 	// Create a printer able to print the pipeline node.
 	prb := jsextended.PrinterBuilder()
-	prb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+	prb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 		switch v := node.(type) {
 		case *InfixPipeOp:
 			ctx := pr.PushContext()
@@ -80,7 +80,7 @@ func Example_infixOp_pipeline() {
 			pr.Print(v.Token)
 			return nil
 		}
-		return next(node)
+		return next(pr, node)
 	})
 
 	// parsing

--- a/xjs_postfixop_test.go
+++ b/xjs_postfixop_test.go
@@ -38,13 +38,13 @@ func Example_postfixOp_factorial() {
 
 	// Create a printer able to print the factorial node.
 	cb := xjs.PrinterBuilder()
-	cb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+	cb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 		switch v := node.(type) {
 		case *PostfixFactorialOp:
 			pr.Print("(function fact(n) { return n <= 1 ? 1 : n * fact(n - 1); })(", v.Value, ")")
 			return nil
 		}
-		return next(node)
+		return next(pr, node)
 	})
 
 	// parsing

--- a/xjs_prefixop_test.go
+++ b/xjs_prefixop_test.go
@@ -87,7 +87,7 @@ func htmlPrefixParser(p *parser.Parser, next func(*parser.Parser) (ast.Expr, err
 }
 
 // "Teach" the printer how to compile our custom nodes.
-func htmlCompiler(pr *printer.Printer, node ast.Node, next func(node ast.Node) error) error {
+func htmlCompiler(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 	switch v := node.(type) {
 	case *PrefixTagOp:
 		pr.Print("(function(){")
@@ -97,7 +97,7 @@ func htmlCompiler(pr *printer.Printer, node ast.Node, next func(node ast.Node) e
 		}
 		pr.Print("return elem;})()")
 	default:
-		return next(node)
+		return next(pr, node)
 	}
 	return nil
 }

--- a/xjs_stmt_test.go
+++ b/xjs_stmt_test.go
@@ -52,7 +52,7 @@ func Example_stmt_defer() {
 
 	// Create a compiler able to compile the defer node.
 	cb := xjs.PrinterBuilder()
-	cb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(ast.Node) error) error {
+	cb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 		switch v := node.(type) {
 		case *DeferStmt:
 			pr.PrintTrivia(v.Defer.LeadingTrivia) // print previous comments and new lines
@@ -61,12 +61,12 @@ func Example_stmt_defer() {
 			pr.Print("}}}")
 			return nil
 		}
-		return next(node)
+		return next(pr, node)
 	})
 
 	// create a formatter that can format `DeferStmt`
 	fb := xjs.PrinterBuilder()
-	fb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(ast.Node) error) error {
+	fb.UsePrinter(func(pr *printer.Printer, node ast.Node, next func(*printer.Printer, ast.Node) error) error {
 		if node, ok := node.(*DeferStmt); ok {
 			pr.Line().Print(node.Defer)
 			pr.Space() // ensure a new space is added
@@ -77,7 +77,7 @@ func Example_stmt_defer() {
 			}
 			return nil
 		}
-		return next(node)
+		return next(pr, node)
 	})
 
 	input := `


### PR DESCRIPTION
This PR introduces a breaking API change.

**How to reproduce**
```bash
git checkout main
go test -bench="^BenchmarkPrint$" -benchmem -count=10 ./jsextended/... > before.out

git checkout perf/eliminate-closure-allocation-in-middleware-chain
go test -bench="^BenchmarkPrint$" -benchmem -count=10 ./jsextended/... > after.out

benchstat before.out after.out
```

**Results** (Apple M1 Pro, Go 1.26.2):
```
goos: darwin
goarch: arm64
pkg: github.com/xjslang/xjs/jsextended
cpu: Apple M1 Pro
        │ before.out  │              after.out              │
        │   sec/op    │   sec/op     vs base                │
Print-8   2.801m ± 1%   1.973m ± 0%  -29.54% (p=0.000 n=10)

        │  before.out  │              after.out               │
        │     B/op     │     B/op      vs base                │
Print-8   3.057Mi ± 0%   2.365Mi ± 0%  -22.63% (p=0.000 n=10)

        │ before.out  │              after.out              │
        │  allocs/op  │  allocs/op   vs base                │
Print-8   54.83k ± 0%   24.60k ± 0%  -55.13% (p=0.000 n=10)
```