### PR TITLE
perf(scanner): optimize ScanIdentifier

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -14,6 +14,7 @@ type Scanner struct {
 	offset       int
 	line, column int
 	scanner      func(*Scanner) (token.Token, error)
+	currentSize  int
 	currentChar  rune
 }
 
@@ -32,6 +33,7 @@ func (sc *Scanner) ForkFrom(pos token.Position) token.Scanner {
 		line:        pos.Line,
 		column:      pos.Column - 1,
 		scanner:     sc.scanner,
+		currentSize: 0,
 		currentChar: EOF,
 	}
 	if s.scanner == nil {
@@ -47,6 +49,7 @@ func (sc *Scanner) Fork() token.Scanner {
 		offset:      sc.offset,
 		line:        sc.line,
 		column:      sc.column,
+		currentSize: sc.currentSize,
 		currentChar: sc.currentChar,
 	}
 	s.scanner = sc.scanner
@@ -62,6 +65,7 @@ func (sc *Scanner) Apply(s token.Scanner) {
 		sc.offset = v.offset
 		sc.line = v.line
 		sc.column = v.column
+		sc.currentSize = v.currentSize
 		sc.currentChar = v.currentChar
 	default:
 		panic("*Scanner expected")
@@ -73,6 +77,7 @@ func (sc *Scanner) Reset() {
 		sc.scanner = defaultScanner
 	}
 	sc.offset = 0
+	sc.currentSize = 0
 	sc.currentChar = EOF
 	sc.line = 0
 	sc.column = -1
@@ -115,7 +120,7 @@ func (sc *Scanner) AdvanceChar() {
 	default:
 		sc.column++
 	}
-	sc.currentChar = r
+	sc.currentChar, sc.currentSize = r, size
 }
 
 func (sc *Scanner) NextToken() token.Token {
@@ -160,4 +165,8 @@ func (sc *Scanner) skipWhitespaces() {
 	for sc.currentChar == ' ' || sc.currentChar == '\t' {
 		sc.AdvanceChar()
 	}
+}
+
+func (sc *Scanner) prevOffset() int {
+	return sc.offset - sc.currentSize
 }

--- a/scanner/scanners.go
+++ b/scanner/scanners.go
@@ -6,12 +6,10 @@ import (
 )
 
 func ScanIdentifier(sc *Scanner) string {
-	sb := strings.Builder{}
-	sb.WriteRune(sc.currentChar)
+	ofs := sc.prevOffset()
 	for sc.AdvanceChar(); IsLetter(sc.currentChar) || IsDigit(sc.currentChar); sc.AdvanceChar() {
-		sb.WriteRune(sc.currentChar)
 	}
-	return sb.String()
+	return string(sc.input[ofs:sc.prevOffset()])
 }
 
 func ScanLineComment(sc *Scanner) string {


### PR DESCRIPTION
**How to reproduce**
```bash
git checkout perf/optimize-ScanIdentifier
mage benchCompare main BenchmarkNextToken
```
**Results** (go 1.26.2)
```
goos: darwin
goarch: arm64
pkg: github.com/xjslang/xjs/scanner
cpu: Apple M1 Pro
            │ before.out  │             after.out              │
            │   sec/op    │   sec/op     vs base               │
NextToken-8   6.145m ± 1%   6.018m ± 1%  -2.06% (p=0.000 n=10)

            │  before.out  │              after.out              │
            │     B/op     │     B/op      vs base               │
NextToken-8   749.7Ki ± 0%   713.0Ki ± 0%  -4.90% (p=0.000 n=10)

            │ before.out  │              after.out              │
            │  allocs/op  │  allocs/op   vs base                │
NextToken-8   21.60k ± 0%   17.41k ± 0%  -19.36% (p=0.000 n=10)
```