### PR TITLE
perf(scanner): optimize scanners

### DIFF
--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -18,6 +18,7 @@ func (s *Scanner) useScanner(scanner func(s *Scanner, next func(*Scanner) (token
 }
 
 func defaultScanner(s *Scanner) (tok token.Token, err error) {
+	ofs0 := s.offset - s.currentSize
 	switch s.currentChar {
 	// operators
 	case '=':
@@ -98,14 +99,15 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 		s.AdvanceChar()
 		switch s.currentChar {
 		case '/':
-			lit := ScanLineComment(s)
+			ScanLineComment(s)
+			lit := string(s.input[ofs0 : s.offset-s.currentSize])
 			tok.Type, tok.Literal = token.LINE_COMMENT, lit
 		case '*':
 			tok.Type = token.BLOCK_COMMENT
-			if tok.Literal, err = ScanBlockComment(s); err != nil {
+			if err = ScanBlockComment(s); err != nil {
 				tok.Type = token.ILLEGAL
-				return
 			}
+			tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
 		default:
 			tok.Type, tok.Literal = token.DIVIDE, "/"
 		}
@@ -114,27 +116,27 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 		c := s.currentChar
 		s.AdvanceChar()
 		tok.Type = token.STRING
-		if tok.Literal, err = ScanString(s, c); err != nil {
+		if err = ScanString(s, c); err != nil {
 			tok.Type = token.ILLEGAL
-			return
 		}
+		tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
 	case '`':
 		s.AdvanceChar()
 		tok.Type = token.STRING
-		if tok.Literal, err = ScanRawString(s); err != nil {
+		if err = ScanRawString(s); err != nil {
 			tok.Type = token.ILLEGAL
-			return
 		}
+		tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
 	case ',':
 		s.AdvanceChar()
 		tok.Type, tok.Literal = token.COMMA, ","
 	case '.':
 		if IsDigit(s.PeekChar()) {
 			tok.Type = token.NUMBER
-			if tok.Literal, err = ScanNumber(s); err != nil {
+			if err = ScanNumber(s); err != nil {
 				tok.Type = token.ILLEGAL
-				return
 			}
+			tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
 		} else {
 			s.AdvanceChar()
 			tok.Type, tok.Literal = token.DOT, "."
@@ -177,14 +179,15 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 		tok.Type, tok.Literal = token.NEWLINE, "\n"
 	default:
 		if IsLetter(s.currentChar) {
-			lit := ScanIdentifier(s)
+			ScanIdentifier(s)
+			lit := string(s.input[ofs0 : s.offset-s.currentSize])
 			tok.Type, tok.Literal = token.IDENT, lit
 		} else if IsDigit(s.currentChar) {
 			tok.Type = token.NUMBER
-			if tok.Literal, err = ScanNumber(s); err != nil {
+			if err = ScanNumber(s); err != nil {
 				tok.Type = token.ILLEGAL
-				return
 			}
+			tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
 		} else if s.currentChar == utf8.RuneError {
 			c := s.currentChar
 			s.AdvanceChar()

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -166,7 +166,3 @@ func (sc *Scanner) skipWhitespaces() {
 		sc.AdvanceChar()
 	}
 }
-
-func (sc *Scanner) prevOffset() int {
-	return sc.offset - sc.currentSize
-}

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -526,7 +526,7 @@ func TestScanNumber(t *testing.T) {
 		for _, input := range inputs {
 			sb := scanner.Builder{}
 			sc := sb.Build([]byte(input))
-			_, err := scanner.ScanNumber(sc)
+			err := scanner.ScanNumber(sc)
 			assert.Error(t, err)
 		}
 	})

--- a/scanner/scanners.go
+++ b/scanner/scanners.go
@@ -2,98 +2,75 @@ package scanner
 
 import (
 	"errors"
-	"strings"
 )
 
-func ScanIdentifier(sc *Scanner) string {
-	ofs := sc.prevOffset()
+func ScanIdentifier(sc *Scanner) {
 	for sc.AdvanceChar(); IsLetter(sc.currentChar) || IsDigit(sc.currentChar); sc.AdvanceChar() {
 	}
-	return string(sc.input[ofs:sc.prevOffset()])
 }
 
-func ScanLineComment(sc *Scanner) string {
-	sb := strings.Builder{}
-	sb.WriteString("//")
+func ScanLineComment(sc *Scanner) {
 	for {
 		sc.AdvanceChar()
 		if sc.currentChar == '\n' {
-			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 			break
 		} else if sc.currentChar == '\r' {
-			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 			if sc.currentChar == '\n' {
-				sb.WriteRune(sc.currentChar)
 				sc.AdvanceChar()
 			}
 			break
 		} else if sc.currentChar == EOF {
 			break
 		}
-		sb.WriteRune(sc.currentChar)
 	}
-	return sb.String()
 }
 
-func ScanBlockComment(sc *Scanner) (string, error) {
-	sb := strings.Builder{}
-	sb.WriteString("/*")
+func ScanBlockComment(sc *Scanner) error {
 	sc.AdvanceChar() // consume "*"
 	for {
 		if sc.currentChar == '*' && sc.PeekChar() == '/' {
 			// consume "*/"
 			for range 2 {
-				sb.WriteRune(sc.currentChar)
 				sc.AdvanceChar()
 			}
 			break
 		} else if sc.currentChar == EOF {
-			return sb.String(), errors.New("unexpected end of file")
+			return errors.New("unexpected end of file")
 		}
-		sb.WriteRune(sc.currentChar)
 		sc.AdvanceChar()
 	}
-	return sb.String(), nil
+	return nil
 }
 
-func ScanString(sc *Scanner, delimiter rune) (string, error) {
-	sb := strings.Builder{}
-	sb.WriteRune(delimiter)
+func ScanString(sc *Scanner, delimiter rune) error {
 	for {
 		if sc.currentChar == '\\' {
-			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 			if sc.currentChar == delimiter || sc.currentChar == '\n' {
-				sb.WriteRune(sc.currentChar)
 				sc.AdvanceChar()
 				continue
 			} else if sc.currentChar == '\r' {
-				sb.WriteRune(sc.currentChar)
 				sc.AdvanceChar()
 				if sc.currentChar == '\n' {
-					sb.WriteRune(sc.currentChar)
 					sc.AdvanceChar()
 				}
 				continue
 			}
 		}
 		if sc.currentChar == delimiter {
-			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 			break
 		} else if sc.currentChar == EOF || sc.currentChar == '\n' || sc.currentChar == '\r' {
-			return sb.String(), errors.New("unexpected end of line")
+			return errors.New("unexpected end of line")
 		}
-		sb.WriteRune(sc.currentChar)
 		sc.AdvanceChar()
 	}
-	return sb.String(), nil
+	return nil
 }
 
-func ScanRawString(sc *Scanner) (string, error) {
-	sb := strings.Builder{}
+func ScanRawString(sc *Scanner) error {
 	scanHole := func() error {
 		depth := 1
 		for {
@@ -101,8 +78,7 @@ func ScanRawString(sc *Scanner) (string, error) {
 				return errors.New("unexpected end of file")
 			} else if sc.currentChar == '`' {
 				sc.AdvanceChar()
-				s, err := ScanRawString(sc)
-				sb.WriteString(s)
+				err := ScanRawString(sc)
 				if err != nil {
 					return err
 				}
@@ -111,66 +87,52 @@ func ScanRawString(sc *Scanner) (string, error) {
 				depth++
 			} else if sc.currentChar == '}' {
 				depth--
-				sb.WriteRune(sc.currentChar)
 				sc.AdvanceChar()
 				if depth == 0 {
 					return nil
 				}
 				continue
 			}
-			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 		}
 	}
 
-	sb.WriteRune('`')
 	for {
 		if sc.currentChar == '`' {
-			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 			break
 		} else if sc.currentChar == '\\' {
-			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 			switch sc.currentChar {
 			case '`', '$':
-				sb.WriteRune(sc.currentChar)
 				sc.AdvanceChar()
 				continue
 			}
 		} else if sc.currentChar == '$' {
-			sb.WriteRune(sc.currentChar)
 			sc.AdvanceChar()
 			if sc.currentChar == '{' {
-				sb.WriteRune(sc.currentChar)
 				sc.AdvanceChar()
 				if err := scanHole(); err != nil {
-					return sb.String(), err
+					return err
 				}
 			}
 			continue
 		} else if sc.currentChar == EOF {
-			return sb.String(), errors.New("unexpected end of file")
+			return errors.New("unexpected end of file")
 		}
-		sb.WriteRune(sc.currentChar)
 		sc.AdvanceChar()
 	}
-	return sb.String(), nil
+	return nil
 }
 
-func ScanNumber(sc *Scanner) (_ string, err error) {
-	var sb strings.Builder
-	next := func() {
-		sb.WriteRune(sc.currentChar)
-		sc.AdvanceChar()
-	}
+func ScanNumber(sc *Scanner) (err error) {
 	scanDigits := func(check func(rune) bool) error {
-		next()
+		sc.AdvanceChar()
 		if !check(sc.currentChar) {
 			return errors.New("digit expected")
 		}
 		for check(sc.currentChar) {
-			next()
+			sc.AdvanceChar()
 		}
 		if IsLetter(sc.currentChar) || IsDigit(sc.currentChar) {
 			return errors.New("digit expected")
@@ -179,24 +141,24 @@ func ScanNumber(sc *Scanner) (_ string, err error) {
 	}
 	scanDecimal := func() error {
 		for IsDigit(sc.currentChar) {
-			next()
+			sc.AdvanceChar()
 		}
 		if sc.currentChar == '.' {
-			next()
+			sc.AdvanceChar()
 		}
 		for IsDigit(sc.currentChar) {
-			next()
+			sc.AdvanceChar()
 		}
 		if c := sc.currentChar; c == 'e' || c == 'E' {
-			next()
+			sc.AdvanceChar()
 			if c := sc.currentChar; c == '+' || c == '-' {
-				next()
+				sc.AdvanceChar()
 			}
 			if !IsDigit(sc.currentChar) {
 				return errors.New("digit expected")
 			}
 			for {
-				next()
+				sc.AdvanceChar()
 				if !IsDigit(sc.currentChar) {
 					break
 				}
@@ -209,7 +171,7 @@ func ScanNumber(sc *Scanner) (_ string, err error) {
 	}
 	switch sc.currentChar {
 	case '0':
-		next()
+		sc.AdvanceChar()
 		switch sc.currentChar {
 		case 'x', 'X':
 			err = scanDigits(IsHexDigit)
@@ -220,7 +182,7 @@ func ScanNumber(sc *Scanner) (_ string, err error) {
 		default:
 			if IsDigit(sc.currentChar) {
 				for IsDigit(sc.currentChar) {
-					next()
+					sc.AdvanceChar()
 				}
 				if c := sc.currentChar; (c == '.' && IsDigit(sc.PeekChar())) || c == 'e' || c == 'E' {
 					err = scanDecimal()
@@ -234,9 +196,9 @@ func ScanNumber(sc *Scanner) (_ string, err error) {
 	}
 	if err != nil {
 		for IsLetter(sc.currentChar) || IsDigit(sc.currentChar) {
-			next()
+			sc.AdvanceChar()
 		}
-		return sb.String(), err
+		return err
 	}
-	return sb.String(), nil
+	return nil
 }


### PR DESCRIPTION
This PR introduces a breaking API change.

**How to reproduce**
```bash
git checkout perf/optimize-scanners
mage benchCompare main BenchmarkNextToken
```

**Results** (go 1.26.2)
```
goos: darwin
goarch: arm64
pkg: github.com/xjslang/xjs/scanner
cpu: Apple M1 Pro
            │ before.out  │             after.out              │
            │   sec/op    │   sec/op     vs base               │
NextToken-8   6.041m ± 1%   5.795m ± 1%  -4.07% (p=0.000 n=10)

            │  before.out  │              after.out               │
            │     B/op     │     B/op      vs base                │
NextToken-8   713.0Ki ± 0%   641.6Ki ± 0%  -10.02% (p=0.000 n=10)

            │ before.out  │              after.out              │
            │  allocs/op  │  allocs/op   vs base                │
NextToken-8   17.41k ± 0%   12.15k ± 0%  -30.26% (p=0.000 n=10)
```