### PR TITLE
perf: replace Token.LeadingTrivia from []token.Token to string

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -168,13 +168,14 @@ func (pr *Printer) Print(args ...any) {
 	}
 }
 
-func (pr *Printer) PrintTrivia(trivia []token.Token) {
+func (pr *Printer) PrintTrivia(trivia string) {
 	if !pr.withTrivia {
 		return
 	}
+	lines := splitTrivia(trivia)
 	es, e := pr.ensureChar, pr.ensure
-	for _, tok := range trivia {
-		if tok.Type == token.NEWLINE {
+	for _, line := range lines {
+		if line == "\n" {
 			if pr.withNewLines {
 				pr.writeRune('\n')
 			}
@@ -182,7 +183,7 @@ func (pr *Printer) PrintTrivia(trivia []token.Token) {
 		}
 		pr.printSpaceIfNeeded()
 		pr.printIndentIfNeeded()
-		pr.writeString(tok.Literal)
+		pr.writeString(line)
 	}
 	pr.ensureChar, pr.ensure = es, e
 }

--- a/printer/util.go
+++ b/printer/util.go
@@ -1,6 +1,10 @@
 package printer
 
-import "github.com/xjslang/xjs/token"
+import (
+	"strings"
+
+	"github.com/xjslang/xjs/token"
+)
 
 func ErrorAt(pos token.Position, msg string) error {
 	return Error{
@@ -15,4 +19,44 @@ func isNewLine(r rune) bool {
 
 func isWhitespace(r rune) bool {
 	return isNewLine(r) || r == ' ' || r == '\t'
+}
+
+func splitTrivia(trivia string) []string {
+	var lines []string
+	sb := strings.Builder{}
+	skipSpaces := true
+	skipLF := false
+	for _, c := range trivia {
+		if skipLF {
+			skipLF = false
+			if c == '\n' {
+				continue
+			}
+		}
+		if skipSpaces && (c == ' ' || c == '\t') {
+			continue
+		}
+		switch c {
+		case '\r':
+			sb.WriteRune('\n') // normalize CR/CRLF to LF
+			lines = append(lines, sb.String())
+			sb.Reset()
+			skipSpaces = true
+			skipLF = true
+			continue
+		case '\n':
+			sb.WriteRune('\n')
+			lines = append(lines, sb.String())
+			sb.Reset()
+			skipSpaces = true
+			continue
+		default:
+			sb.WriteRune(c)
+			skipSpaces = false
+		}
+	}
+	if s := sb.String(); len(s) > 0 {
+		lines = append(lines, strings.TrimRight(s, " "))
+	}
+	return lines
 }

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -97,20 +97,7 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 	// divide operator and comments
 	case '/':
 		s.AdvanceChar()
-		switch s.currentChar {
-		case '/':
-			ScanLineComment(s)
-			lit := string(s.input[ofs0 : s.offset-s.currentSize])
-			tok.Type, tok.Literal = token.LINE_COMMENT, lit
-		case '*':
-			tok.Type = token.BLOCK_COMMENT
-			if err = ScanBlockComment(s); err != nil {
-				tok.Type = token.ILLEGAL
-			}
-			tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
-		default:
-			tok.Type, tok.Literal = token.DIVIDE, "/"
-		}
+		tok.Type, tok.Literal = token.DIVIDE, "/"
 	// delimiters
 	case '\'', '"':
 		c := s.currentChar

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -124,45 +124,21 @@ func (sc *Scanner) AdvanceChar() {
 }
 
 func (sc *Scanner) NextToken() token.Token {
-	next := func() token.Token {
-		sc.skipWhitespaces()
-		line, column, offset := sc.line, sc.column, sc.offset
-		tok, err := sc.scanner(sc)
-		// TODO: (medium) Scanner.NextToken converts scanner/middleware errors into token.ILLEGAL but discards the error value entirely. With the new middleware signature returning errors, callers still have no way to observe why a token is illegal other than inspecting Literal. Consider exposing the error (e.g., NextToken returning (token.Token, error) or storing the last error on Scanner) so downstream code can surface better diagnostics.
-		if err != nil {
-			tok.Type = token.ILLEGAL
-		}
-		tok.Line = line
-		tok.Column = max(0, column)
-		tok.Offset = offset
-		if sc.currentChar != EOF {
-			tok.Offset = offset - utf8.RuneLen(sc.currentChar)
-		}
-		return tok
-	}
-	var trivia []token.Token
-	afterNewline := false
-	tok := next()
-triviaLoop:
-	for {
-		switch tok.Type {
-		case token.NEWLINE:
-			afterNewline = true
-		case token.LINE_COMMENT, token.BLOCK_COMMENT:
-			afterNewline = afterNewline || strings.ContainsAny(tok.Literal, "\n\r")
-		default:
-			break triviaLoop
-		}
-		trivia = append(trivia, tok)
-		tok = next()
-	}
-	tok.LeadingTrivia = trivia
-	tok.AfterNewline = afterNewline
-	return tok
-}
+	ofs0 := sc.offset - sc.currentSize
+	triviaErr := scanTrivia(sc)
+	leadingTrivia := string(sc.input[ofs0 : sc.offset-sc.currentSize])
+	afterNewline := strings.ContainsAny(leadingTrivia, "\n\r")
+	line, column := sc.line, sc.column
+	startOffset := sc.offset - sc.currentSize
 
-func (sc *Scanner) skipWhitespaces() {
-	for sc.currentChar == ' ' || sc.currentChar == '\t' {
-		sc.AdvanceChar()
+	tok, err := sc.scanner(sc)
+	tok.LeadingTrivia = leadingTrivia
+	tok.AfterNewline = afterNewline
+	tok.Line = line
+	tok.Column = max(0, column)
+	tok.Offset = startOffset
+	if triviaErr != nil || err != nil {
+		tok.Type = token.ILLEGAL
 	}
+	return tok
 }

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -56,19 +56,8 @@ func AssertTokens(t *testing.T, toks, expectedToks []token.Token, opts ...TokenC
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
 		case cfg.afterNewline && tok.AfterNewline != expectedTok.AfterNewline:
 			t.Errorf("token %d: expected AfterNewline to be %t, got %t", i, expectedTok.AfterNewline, tok.AfterNewline)
-		case cfg.leadingTrivia:
-			if len(tok.LeadingTrivia) != len(expectedTok.LeadingTrivia) {
-				t.Errorf("token %d: expected %d leading trivia lines, got %d", i, len(expectedTok.LeadingTrivia), len(tok.LeadingTrivia))
-			} else {
-				for j, expectedTrivia := range expectedTok.LeadingTrivia {
-					trivia := tok.LeadingTrivia[j]
-					if trivia.Type != expectedTrivia.Type {
-						t.Errorf("token %d: expected trivia type to be %v, got %v", i, expectedTrivia.Type, trivia.Type)
-					} else if trivia.Literal != expectedTrivia.Literal {
-						t.Errorf("token %d: expected trivia to be %q, got %q", i, expectedTrivia.Literal, trivia.Literal)
-					}
-				}
-			}
+		case cfg.leadingTrivia && tok.LeadingTrivia != expectedTok.LeadingTrivia:
+			t.Errorf("token %d: expected LeadingTrivia to be %q, got %q", i, expectedTok.LeadingTrivia, tok.LeadingTrivia)
 		case cfg.tokenPosition && (tok.Line != expectedTok.Line || tok.Column != expectedTok.Column):
 			t.Errorf("token %d: expected position to be (%d, %d), got (%d, %d)", i, expectedTok.Line, expectedTok.Column, tok.Line, tok.Column)
 		}
@@ -126,7 +115,7 @@ func ExampleBuilder_Build() {
 	// {Type: HASH, Literal: #, Position: {0 0 0}}
 	// {Type: IDENT, Literal: some, Position: {0 1 1}}
 	// {Type: CARET, Literal: ^, Position: {0 6 6}}
-	// {Type: IDENT, Literal: input, Position: {0 7 8}}
+	// {Type: IDENT, Literal: input, Position: {0 7 7}}
 }
 
 func BenchmarkNextToken(b *testing.B) {
@@ -312,15 +301,9 @@ func TestAfterNewline(t *testing.T) {
 func TestBlockComments(t *testing.T) {
 	input := "/* lorem\nipsum dolor */\n\rhello\r\n/* unfinished comment"
 	assertInputTokens(t, input, []token.Token{
-		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []token.Token{
-			{Type: token.BLOCK_COMMENT, Literal: "/* lorem\nipsum dolor */"},
-			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: token.NEWLINE, Literal: "\r"},
-		}},
-		{Type: token.ILLEGAL, Literal: "/* unfinished comment", LeadingTrivia: []token.Token{
-			{Type: token.NEWLINE, Literal: "\r\n"},
-		}},
-		{Type: token.EOF},
+		{Type: token.IDENT, Literal: "hello", LeadingTrivia: "/* lorem\nipsum dolor */\n\r"},
+		{Type: token.ILLEGAL, Literal: "", LeadingTrivia: "\r\n/* unfinished comment"},
+		{Type: token.EOF, Literal: ""},
 	}, CompareLeadingTrivia())
 }
 
@@ -328,55 +311,31 @@ func TestLineComments(t *testing.T) {
 	input := `
   // First Name
   John
-  
+
   // Last Name
   Smith
-	
+
 	// Final comment`
 	assertInputTokens(t, input, []token.Token{
-		{Type: token.IDENT, Literal: "John", LeadingTrivia: []token.Token{
-			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: token.LINE_COMMENT, Literal: "// First Name\n"},
-		}},
-		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: []token.Token{
-			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: token.LINE_COMMENT, Literal: "// Last Name\n"},
-		}},
-		{Type: token.EOF, LeadingTrivia: []token.Token{
-			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: token.NEWLINE, Literal: "\n"},
-			{Type: token.LINE_COMMENT, Literal: "// Final comment"},
-		}},
+		{Type: token.IDENT, Literal: "John", LeadingTrivia: "\n  // First Name\n  "},
+		{Type: token.IDENT, Literal: "Smith", LeadingTrivia: "\n\n  // Last Name\n  "},
+		{Type: token.EOF, LeadingTrivia: "\n\n\t// Final comment"},
 	}, CompareLeadingTrivia())
 }
 
 func TestEmptySinglelineComment(t *testing.T) {
 	assertInputTokens(t, "//\nhello//\n\npeople//\r\nthere//\r!//", []token.Token{
-		{Type: token.IDENT, Literal: "hello", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "//\n"},
-		}},
-		{Type: token.IDENT, Literal: "people", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "//\n"},
-			{Type: token.NEWLINE, Literal: "\n"},
-		}},
-		{Type: token.IDENT, Literal: "there", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "//\r\n"},
-		}},
-		{Type: token.NOT, Literal: "!", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "//\r"},
-		}},
-		{Type: token.EOF, Literal: "", LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "//"},
-		}},
+		{Type: token.IDENT, Literal: "hello", LeadingTrivia: "//\n"},
+		{Type: token.IDENT, Literal: "people", LeadingTrivia: "//\n\n"},
+		{Type: token.IDENT, Literal: "there", LeadingTrivia: "//\r\n"},
+		{Type: token.NOT, Literal: "!", LeadingTrivia: "//\r"},
+		{Type: token.EOF, Literal: "", LeadingTrivia: "//"},
 	}, CompareLeadingTrivia())
 }
 
 func TestLastLineComment(t *testing.T) {
 	assertInputTokens(t, "// last comment", []token.Token{
-		{Type: token.EOF, Literal: "", AfterNewline: false, LeadingTrivia: []token.Token{
-			{Type: token.LINE_COMMENT, Literal: "// last comment"},
-		}},
+		{Type: token.EOF, Literal: "", AfterNewline: false, LeadingTrivia: "// last comment"},
 	}, CompareLeadingTrivia(), CompareAfterNewline())
 }
 

--- a/scanner/scanners.go
+++ b/scanner/scanners.go
@@ -202,3 +202,32 @@ func ScanNumber(sc *Scanner) (err error) {
 	}
 	return nil
 }
+
+func scanTrivia(sc *Scanner) error {
+loop:
+	for {
+		// skip spaces
+		for {
+			if c := sc.currentChar; c != ' ' && c != '\t' && c != '\n' && c != '\r' {
+				break
+			}
+			sc.AdvanceChar()
+		}
+		if sc.currentChar != '/' {
+			break
+		}
+		switch sc.PeekChar() {
+		case '/':
+			sc.AdvanceChar()
+			ScanLineComment(sc)
+		case '*':
+			sc.AdvanceChar()
+			if err := ScanBlockComment(sc); err != nil {
+				return err
+			}
+		default:
+			break loop
+		}
+	}
+	return nil
+}

--- a/token/token.go
+++ b/token/token.go
@@ -49,7 +49,7 @@ type Token struct {
 	Position
 	Type          Type
 	Literal       string
-	LeadingTrivia []Token
+	LeadingTrivia string
 	AfterNewline  bool
 }
 
@@ -93,10 +93,8 @@ const (
 	RBRACKET  // ]
 	NEWLINE   // \r, \n, \r\n
 	// others
-	NUMBER        // 3.1415
-	LINE_COMMENT  // // ..
-	BLOCK_COMMENT // /* .. */
-	STRING        // '..' or ".."
+	NUMBER // 3.1415
+	STRING // '..' or ".."
 )
 
 var tokenInfo = map[Type]struct {
@@ -141,10 +139,8 @@ var tokenInfo = map[Type]struct {
 	RBRACKET:  {"RBRACKET", "]"},
 	NEWLINE:   {"NEWLINE", "new line"},
 	// others
-	LINE_COMMENT:  {"LINE_COMMENT", ""},
-	BLOCK_COMMENT: {"BLOCK_COMMENT", ""},
-	STRING:        {"STRING", ""},
-	NUMBER:        {"NUMBER", ""},
+	STRING: {"STRING", ""},
+	NUMBER: {"NUMBER", ""},
 }
 
 const initCustomType Type = 1000

--- a/xjs_infixop_test.go
+++ b/xjs_infixop_test.go
@@ -65,7 +65,7 @@ func Example_infixOp_pipeline() {
 			ctx["it"] = v.Left
 			if w, ok := v.Left.(*js.Variable); ok {
 				// TODO: relocate comments to the right member
-				w.LeadingTrivia = nil
+				w.LeadingTrivia = ""
 			}
 			pr.Print(v.Right)
 			return nil


### PR DESCRIPTION
This PR introduces a breaking API change.

**How to reproduce**
```bash
git checkout perf/replace-Token.LeadingTrivia-from-slice-token.Token-to-string
mage benchCompare main BenchmarkNextToken
```

**Results** (go 1.26.2)
```
goos: darwin
goarch: arm64
pkg: github.com/xjslang/xjs/scanner
cpu: Apple M1 Pro
            │ before.out  │              after.out              │
            │   sec/op    │   sec/op     vs base                │
NextToken-8   5.800m ± 3%   3.947m ± 2%  -31.94% (p=0.000 n=10)

            │  before.out   │              after.out               │
            │     B/op      │     B/op      vs base                │
NextToken-8   641.57Ki ± 0%   99.00Ki ± 0%  -84.57% (p=0.000 n=10)

            │  before.out  │              after.out              │
            │  allocs/op   │  allocs/op   vs base                │
NextToken-8   12.146k ± 0%   7.447k ± 0%  -38.69% (p=0.000 n=10)
```