### PR TITLE
perf(scanner): change Scanner.init() signature

### DIFF
--- a/examples/jsx/jsx.go
+++ b/examples/jsx/jsx.go
@@ -102,7 +102,7 @@ func jsxInfixOpParser(p *parser.Parser, left ast.Expr, next func(*parser.Parser,
 	return next(p, left)
 }
 
-func Parse(input []byte) (*js.Program, error) {
+func Parse(input string) (*js.Program, error) {
 	token.RegisterPrefixOp(startTag)
 	token.RegisterInfixOp(concatTag, token.OR.Precedence())
 

--- a/examples/jsx/jsx_test.go
+++ b/examples/jsx/jsx_test.go
@@ -15,7 +15,7 @@ func ExampleCompile() {
 		"Hello, " |
 		<strong>"World!"</strong>
 	</p>`
-	result, err := jsx.Parse([]byte(input))
+	result, err := jsx.Parse(input)
 	if err != nil {
 		panic(err)
 	}
@@ -32,7 +32,7 @@ func ExampleCompile() {
 func ExampleFormat() {
 	// transform the input to AST
 	input := `let p = <p>"Hello, " | <strong>"World!"</strong></p>`
-	result, err := jsx.Parse([]byte(input))
+	result, err := jsx.Parse(input)
 	if err != nil {
 		panic(err)
 	}
@@ -54,7 +54,7 @@ func ExampleFormat() {
 func TestParse(t *testing.T) {
 	t.Run("errors", func(t *testing.T) {
 		input := "<div>'Hello, World!'</p>"
-		_, err := jsx.Parse([]byte(input))
+		_, err := jsx.Parse(input)
 		require.Error(t, err)
 		require.Equal(t, err.Error(), "[line:0, col:22] expected closing tag </div>")
 	})
@@ -63,7 +63,7 @@ func TestParse(t *testing.T) {
 func TestCompile(t *testing.T) {
 	t.Run("empty tag", func(t *testing.T) {
 		input := `let p = <p></p>`
-		result, err := jsx.Parse([]byte(input))
+		result, err := jsx.Parse(input)
 		require.NoError(t, err)
 		out, err := jsx.Compile(result)
 		require.NoError(t, err)
@@ -74,7 +74,7 @@ func TestCompile(t *testing.T) {
 func TestFormat(t *testing.T) {
 	t.Run("empty tags", func(t *testing.T) {
 		input := `let p = <p></p>`
-		result, err := jsx.Parse([]byte(input))
+		result, err := jsx.Parse(input)
 		require.NoError(t, err)
 		out, err := jsx.Format(result)
 		require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestFormat(t *testing.T) {
 		<strong>
 		/* c2 */
 		"World!"</strong></p>`
-		result, err := jsx.Parse([]byte(input))
+		result, err := jsx.Parse(input)
 		require.NoError(t, err)
 
 		// transform the AST to properly formatted code

--- a/examples/xjscli/main.go
+++ b/examples/xjscli/main.go
@@ -67,7 +67,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	program, err := internal.Parse(data)
+	program, err := internal.Parse(string(data))
 
 	// prints errors
 	if checkFlag {

--- a/internal/helpers.go
+++ b/internal/helpers.go
@@ -7,7 +7,7 @@ import (
 	"github.com/xjslang/xjs/printer"
 )
 
-func Parse(input []byte) (*js.Program, error) {
+func Parse(input string) (*js.Program, error) {
 	sc := xjs.ScannerBuilder().Build(input)
 	p := xjs.ParserBuilder().Build(sc)
 	return js.ParseProgram(p)

--- a/js/js_test.go
+++ b/js/js_test.go
@@ -23,7 +23,7 @@ func TestRoundtripFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			result, err := internal.Parse(data)
+			result, err := internal.Parse(string(data))
 			require.NoError(t, err)
 
 			// AST -> code
@@ -45,7 +45,7 @@ func TestDebugFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			result, err := internal.Parse(data)
+			result, err := internal.Parse(string(data))
 			require.NoError(t, err)
 
 			// AST -> code
@@ -67,7 +67,7 @@ func TestCheckFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			result, err := internal.Parse(data)
+			result, err := internal.Parse(string(data))
 			require.NoError(t, err)
 
 			// AST -> code
@@ -75,7 +75,7 @@ func TestCheckFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// verify printed code parses
-			_, err = internal.Parse([]byte(code))
+			_, err = internal.Parse(code)
 			require.NoError(t, err)
 		})
 	}
@@ -91,7 +91,7 @@ func TestErrorFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			_, errs := internal.Parse(data)
+			_, errs := internal.Parse(string(data))
 			require.Error(t, errs)
 			require.IsType(t, parser.ErrorList{}, errs)
 

--- a/jsextended/jsextended_test.go
+++ b/jsextended/jsextended_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/xorcare/golden"
 )
 
-func Parse(input []byte) (*js.Program, error) {
+func Parse(input string) (*js.Program, error) {
 	sb := jsextended.ScannerBuilder()
 	sc := sb.Build(input)
 	pb := jsextended.ParserBuilder()
@@ -37,7 +37,8 @@ func BenchmarkParse(b *testing.B) {
 	require.NotEmpty(b, dat)
 
 	// verify that it can be parsed and printed
-	result, err := Parse(dat)
+	src := string(dat)
+	result, err := Parse(src)
 	require.NoError(b, err)
 	code, err := Print(result)
 	require.NoError(b, err)
@@ -45,7 +46,7 @@ func BenchmarkParse(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		_, _ = Parse(dat)
+		_, _ = Parse(src)
 	}
 }
 
@@ -55,7 +56,7 @@ func BenchmarkPrint(b *testing.B) {
 	require.NotEmpty(b, dat)
 
 	// verify that it can be parsed and printed
-	result, err := Parse(dat)
+	result, err := Parse(string(dat))
 	require.NoError(b, err)
 	code, err := Print(result)
 	require.NoError(b, err)
@@ -73,7 +74,8 @@ func BenchmarkParseAndPrint(b *testing.B) {
 	require.NotEmpty(b, dat)
 
 	// verify that it can be parsed and printed
-	result, err := Parse(dat)
+	src := string(dat)
+	result, err := Parse(src)
 	require.NoError(b, err)
 	code, err := Print(result)
 	require.NoError(b, err)
@@ -81,7 +83,7 @@ func BenchmarkParseAndPrint(b *testing.B) {
 
 	b.ResetTimer()
 	for b.Loop() {
-		result, _ = Parse(dat)
+		result, _ = Parse(src)
 		_, _ = Print(result)
 	}
 }
@@ -96,7 +98,7 @@ func TestRoundtripFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			result, err := Parse(data)
+			result, err := Parse(string(data))
 			require.NoError(t, err)
 
 			// AST -> code
@@ -118,7 +120,7 @@ func TestDebugFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			result, err := Parse(data)
+			result, err := Parse(string(data))
 			require.NoError(t, err)
 
 			// AST -> code
@@ -139,13 +141,13 @@ func TestCheckFiles(t *testing.T) {
 			data, err := os.ReadFile(file)
 			require.NoError(t, err)
 
-			result1, err := Parse(data)
+			result1, err := Parse(string(data))
 			require.NoError(t, err)
 
 			code1, err := Print(result1, printer.Compact())
 			require.NoError(t, err)
 
-			result2, err := Parse([]byte(code1))
+			result2, err := Parse(code1)
 			require.NoError(t, err)
 
 			code2, err := Print(result2, printer.Compact())
@@ -165,7 +167,7 @@ func TestErrorFiles(t *testing.T) {
 			require.NoError(t, err)
 
 			// data -> AST
-			_, errs := Parse(data)
+			_, errs := Parse(string(data))
 			require.Error(t, errs)
 			require.IsType(t, parser.ErrorList{}, errs)
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -29,7 +29,7 @@ type MyCustomStmt struct {
 
 func ExampleBuilder_Build() {
 	sb := scanner.Builder{}
-	s := sb.Build([]byte("print('Hello, World!')"))
+	s := sb.Build("print('Hello, World!')")
 	pb := parser.Builder{}
 	p := pb.
 		UseStmtParser(func(p *parser.Parser, next func(*parser.Parser) (ast.Stmt, error)) (_ ast.Stmt, err error) {
@@ -87,7 +87,7 @@ func TestLookahead(t *testing.T) {
 	t.Run("resolved", func(t *testing.T) {
 		input := "b"
 		sb := scanner.Builder{}
-		s := sb.Build([]byte(input))
+		s := sb.Build(input)
 		pb := parser.Builder{}
 		p := pb.Build(s)
 		result, err := parser.Switch(p, func(p *parser.Parser) (*js.Variable, error) {
@@ -103,7 +103,7 @@ func TestLookahead(t *testing.T) {
 	t.Run("not resolved", func(t *testing.T) {
 		input := "c"
 		sb := scanner.Builder{}
-		s := sb.Build([]byte(input))
+		s := sb.Build(input)
 		pb := parser.Builder{}
 		p := pb.Build(s)
 		_, err := parser.Switch(p, func(p *parser.Parser) (*js.Variable, error) {
@@ -127,7 +127,7 @@ func TestMalformedExpr(t *testing.T) {
 			{"{ let x = 100", "} expected"},
 		}
 		for i, test := range tests {
-			s := xjs.ScannerBuilder().Build([]byte(test.input))
+			s := xjs.ScannerBuilder().Build(test.input)
 			p := xjs.ParserBuilder().Build(s)
 			_, err := js.ParseBlockStmt(p)
 			if err == nil {
@@ -147,7 +147,7 @@ func TestMalformedExpr(t *testing.T) {
 			{"(1 + 2", ") expected"},
 		}
 		for i, test := range tests {
-			s := xjs.ScannerBuilder().Build([]byte(test.input))
+			s := xjs.ScannerBuilder().Build(test.input)
 			p := xjs.ParserBuilder().Build(s)
 			_, err := js.ParsePrefixParenOp(p)
 			if err == nil {
@@ -171,7 +171,7 @@ func TestInvalidTokenAfterNewline(t *testing.T) {
 				} else {
 					input = test
 				}
-				s := xjs.ScannerBuilder().Build([]byte(input))
+				s := xjs.ScannerBuilder().Build(input)
 				p := xjs.ParserBuilder().Build(s)
 				var err error
 				if i > 0 {
@@ -230,7 +230,7 @@ func TestExpectWith(t *testing.T) {
 	/lorem ipsum dolor/gd
 	'lorem ipsum'`
 	sb := scanner.Builder{}
-	s := sb.Build([]byte(input))
+	s := sb.Build(input)
 	pb := parser.Builder{}
 	p := pb.Build(s)
 	tok, err := p.ExpectWith(scanRegex)

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -130,7 +130,7 @@ func TestPrintInfixParenOp(t *testing.T) {
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprintf("exp %d", i), func(t *testing.T) {
-			node, err := internal.Parse([]byte(test.input))
+			node, err := internal.Parse(test.input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -166,7 +166,7 @@ func TestLastComment(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			node, err := internal.Parse([]byte(test.input))
+			node, err := internal.Parse(test.input)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -392,7 +392,7 @@ func TestWithComments(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := internal.Parse([]byte(input))
+			result, err := internal.Parse(input)
 			require.NoError(t, err)
 			test.pr.Print(result)
 			out, err := test.pr.Output()
@@ -415,7 +415,7 @@ func TestWithNewLines(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			result, err := internal.Parse([]byte(input))
+			result, err := internal.Parse(input)
 			require.NoError(t, err)
 			test.pr.Print(result)
 			out, err := test.pr.Output()
@@ -436,7 +436,7 @@ func TestCompact(t *testing.T) {
 	let x = 100
 	/* b */
 	let y = 200`
-	result, err := internal.Parse([]byte(input))
+	result, err := internal.Parse(input)
 	require.NoError(t, err)
 	out, err := internal.Print(result, printer.Compact())
 	require.NoError(t, err)
@@ -475,7 +475,7 @@ func TestErrorAt(t *testing.T) {
 	}).Build()
 
 	input := `let x = ..rest`
-	sc := sb.Build([]byte(input))
+	sc := sb.Build(input)
 	p := xjs.ParserBuilder().Build(sc)
 	result, err := js.ParseProgram(p)
 	require.NoError(t, err)
@@ -556,7 +556,7 @@ func TestPrinterContext(t *testing.T) {
 	input := `function fetchUserData() {
 		await http.fetch('/user/data')
 	}`
-	sc := sb.Build([]byte(input))
+	sc := sb.Build(input)
 	p := pb.Build(sc)
 	result, err := js.ParseProgram(p)
 	require.NoError(t, err)

--- a/scanner/builder.go
+++ b/scanner/builder.go
@@ -12,7 +12,8 @@ func (b *Builder) UseScanner(scanner func(sc *Scanner, next func(*Scanner) (toke
 	return b
 }
 
-func (b *Builder) Build(input []byte) *Scanner {
+// TODO: Scanner.Builder.Build now accepts a string and the scanner populates Token.Literal/LeadingTrivia using string slices. In Go, substrings retain a reference to the entire original string, so keeping tokens/AST nodes alive will also keep the full source input alive. If this is intentional for perf, it should be documented on the public Build API (and/or Scanner) so callers understand the memory-ownership tradeoff.
+func (b *Builder) Build(input string) *Scanner {
 	sc := &Scanner{}
 	for _, scanner := range b.scanners {
 		sc.useScanner(scanner)

--- a/scanner/middleware.go
+++ b/scanner/middleware.go
@@ -106,14 +106,14 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 		if err = scanString(s, c); err != nil {
 			tok.Type = token.ILLEGAL
 		}
-		tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
+		tok.Literal = s.input[ofs0 : s.offset-s.currentSize]
 	case '`':
 		s.AdvanceChar()
 		tok.Type = token.STRING
 		if err = scanRawString(s); err != nil {
 			tok.Type = token.ILLEGAL
 		}
-		tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
+		tok.Literal = s.input[ofs0 : s.offset-s.currentSize]
 	case ',':
 		s.AdvanceChar()
 		tok.Type, tok.Literal = token.COMMA, ","
@@ -123,7 +123,7 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 			if err = scanNumber(s); err != nil {
 				tok.Type = token.ILLEGAL
 			}
-			tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
+			tok.Literal = s.input[ofs0 : s.offset-s.currentSize]
 		} else {
 			s.AdvanceChar()
 			tok.Type, tok.Literal = token.DOT, "."
@@ -167,14 +167,14 @@ func defaultScanner(s *Scanner) (tok token.Token, err error) {
 	default:
 		if IsLetter(s.currentChar) {
 			scanIdentifier(s)
-			lit := string(s.input[ofs0 : s.offset-s.currentSize])
+			lit := s.input[ofs0 : s.offset-s.currentSize]
 			tok.Type, tok.Literal = token.IDENT, lit
 		} else if IsDigit(s.currentChar) {
 			tok.Type = token.NUMBER
 			if err = scanNumber(s); err != nil {
 				tok.Type = token.ILLEGAL
 			}
-			tok.Literal = string(s.input[ofs0 : s.offset-s.currentSize])
+			tok.Literal = s.input[ofs0 : s.offset-s.currentSize]
 		} else if s.currentChar == utf8.RuneError {
 			c := s.currentChar
 			s.AdvanceChar()

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -10,7 +10,7 @@ import (
 const EOF = rune(-1)
 
 type Scanner struct {
-	input        []byte
+	input        string
 	offset       int
 	line, column int
 	scanner      func(*Scanner) (token.Token, error)
@@ -18,7 +18,7 @@ type Scanner struct {
 	currentChar  rune
 }
 
-func (s *Scanner) init(input []byte) {
+func (s *Scanner) init(input string) {
 	s.input = input
 	if s.scanner == nil {
 		s.scanner = defaultScanner
@@ -90,14 +90,14 @@ func (s *Scanner) CurrentChar() rune {
 
 func (s *Scanner) PeekChar() rune {
 	if s.offset < len(s.input) {
-		r, _ := utf8.DecodeRune(s.input[s.offset:])
+		r, _ := utf8.DecodeRuneInString(s.input[s.offset:])
 		return r
 	}
 	return EOF
 }
 
 func (s *Scanner) AdvanceChar() {
-	r, size := utf8.DecodeRune(s.input[s.offset:])
+	r, size := utf8.DecodeRuneInString(s.input[s.offset:])
 	s.offset += size
 	// covers "\r", "\n" and "\r\n"
 	switch r {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -79,7 +79,7 @@ func assertLexerTokens(t *testing.T, sc *scanner.Scanner, expectedToks []token.T
 func assertInputTokens(t *testing.T, input string, expectedToks []token.Token, opts ...TokenCompareOption) {
 	t.Helper()
 	sb := scanner.Builder{}
-	s := sb.Build([]byte(input))
+	s := sb.Build(input)
 	assertLexerTokens(t, s, expectedToks, opts...)
 }
 
@@ -102,7 +102,7 @@ func ExampleBuilder_Build() {
 			}
 			return next(sc) // Delegate to the "next" middleware
 		}).
-		Build([]byte("#some ^input"))
+		Build("#some ^input")
 
 	// Now you can use the scanner
 	for tok := s.NextToken(); tok.Type != token.EOF; tok = s.NextToken() {
@@ -133,7 +133,7 @@ func BenchmarkNextToken(b *testing.B) {
 		})
 	}
 
-	s := sb.Build(dat)
+	s := sb.Build(string(dat))
 	b.ResetTimer()
 	for b.Loop() {
 		s.Reset()
@@ -145,7 +145,7 @@ func BenchmarkNextToken(b *testing.B) {
 func TestLookahead(t *testing.T) {
 	input := "a b c d e f"
 	sb := scanner.Builder{}
-	sc := sb.Build([]byte(input))
+	sc := sb.Build(input)
 	var toks []token.Token
 	for range 2 {
 		toks = append(toks, sc.NextToken())
@@ -208,7 +208,7 @@ func TestTokenPosition(t *testing.T) {
 func TestReset(t *testing.T) {
 	items := []string{"lorem", "ipsum", "dolor"}
 	sb := scanner.Builder{}
-	sc := sb.Build([]byte(strings.Join(items, " ")))
+	sc := sb.Build(strings.Join(items, " "))
 	for range 2 {
 		var toks []token.Token
 		for tok := sc.NextToken(); tok.Type != token.EOF; tok = sc.NextToken() {
@@ -453,7 +453,7 @@ func TestUseScanner(t *testing.T) {
 			}
 			return next(sc)
 		}).
-		Build([]byte("5 ** 2"))
+		Build("5 ** 2")
 	assertLexerTokens(t, sc, []token.Token{
 		{Type: token.NUMBER, Literal: "5"},
 		{Type: powType, Literal: "**"},
@@ -471,7 +471,7 @@ func TestScanNumber(t *testing.T) {
 		}
 		for _, input := range inputs {
 			sb := scanner.Builder{}
-			sc := sb.Build([]byte(input))
+			sc := sb.Build(input)
 			tok := sc.NextToken()
 			require.Equal(t, token.ILLEGAL, tok.Type)
 		}
@@ -482,7 +482,7 @@ func TestSpecialRunes(t *testing.T) {
 	inputs := []string{"T\u200c", "A\u200d"}
 	for _, input := range inputs {
 		sb := scanner.Builder{}
-		sc := sb.Build([]byte(input))
+		sc := sb.Build(input)
 		tok := sc.NextToken()
 		require.Equal(t, token.IDENT, tok.Type)
 		require.Equal(t, input, tok.Literal)

--- a/xjs_infixop_test.go
+++ b/xjs_infixop_test.go
@@ -85,7 +85,7 @@ func Example_infixOp_pipeline() {
 
 	// parsing
 	input := `const result = raw |> it.trim() |> it.toLowerCase() |> encodeURIComponent(it);`
-	s := sb.Build([]byte(input))
+	s := sb.Build(input)
 	p := pb.Build(s)
 	result, err := js.ParseProgram(p)
 	if err != nil {

--- a/xjs_postfixop_test.go
+++ b/xjs_postfixop_test.go
@@ -49,7 +49,7 @@ func Example_postfixOp_factorial() {
 
 	// parsing
 	input := `let f = 5!`
-	s := xjs.ScannerBuilder().Build([]byte(input))
+	s := xjs.ScannerBuilder().Build(input)
 	p := pb.Build(s)
 	result, err := js.ParseProgram(p)
 	if err != nil {

--- a/xjs_prefixop_test.go
+++ b/xjs_prefixop_test.go
@@ -116,7 +116,7 @@ func Example_prefixOp_htmlTag() {
 	// the source into tokens
 	sb := xjs.ScannerBuilder()
 	sb.UseScanner(htmlScanner)
-	sc := sb.Build([]byte(source)) // scanner
+	sc := sb.Build(source) // scanner
 
 	// Parsing
 	//

--- a/xjs_stmt_test.go
+++ b/xjs_stmt_test.go
@@ -95,7 +95,7 @@ func Example_stmt_defer() {
 	}`
 
 	// parsing
-	s := sb.Build([]byte(input))
+	s := sb.Build(input)
 	p := pb.Build(s)
 	node, err := js.ParseProgram(p)
 	if err != nil {

--- a/xjs_test.go
+++ b/xjs_test.go
@@ -38,7 +38,7 @@ func ExampleScannerBuilder() {
 	input := `
 	name ~~ "john*"
 	name ~! "admin*"`
-	sc := sb.Build([]byte(input))
+	sc := sb.Build(input)
 	for tok := sc.NextToken(); tok.Type != token.EOF; tok = sc.NextToken() {
 		fmt.Printf("[%q: %s]", tok.Literal, tok.Type.Name())
 	}


### PR DESCRIPTION
This PR introduces a breaking API change.

**How to reproduce**
```bash
mage benchCompare main BenchmarkNextToken
```
**Results** (go 1.26.2)
```
            │ before.out  │             after.out              │
            │   sec/op    │   sec/op     vs base               │
NextToken-8   3.938m ± 1%   3.791m ± 1%  -3.73% (p=0.000 n=10)

            │  before.out   │             after.out              │
            │     B/op      │    B/op     vs base                │
NextToken-8   101376.0 ± 0%   568.0 ± 0%  -99.44% (p=0.000 n=10)

            │ before.out  │             after.out              │
            │  allocs/op  │ allocs/op   vs base                │
NextToken-8   7447.0 ± 0%   133.0 ± 0%  -98.21% (p=0.000 n=10)
```