### PR TITLE
perf(scanner): reduce the size of token.Token struct

### DIFF
--- a/examples/jsx/jsx_test.go
+++ b/examples/jsx/jsx_test.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/xjslang/xjs/examples/jsx"
+	"github.com/xjslang/xjs/parser"
 	"github.com/xjslang/xjs/printer"
+	"github.com/xjslang/xjs/token"
 )
 
 func ExampleCompile() {
@@ -55,8 +57,16 @@ func TestParse(t *testing.T) {
 	t.Run("errors", func(t *testing.T) {
 		input := "<div>'Hello, World!'</p>"
 		_, err := jsx.Parse(input)
-		require.Error(t, err)
-		require.Equal(t, err.Error(), "[line:0, col:22] expected closing tag </div>")
+		var errlist parser.ErrorList
+		require.ErrorAs(t, err, &errlist)
+		require.NotEmpty(t, errlist)
+		var perr parser.Error
+		require.ErrorAs(t, errlist[0], &perr)
+		l0, c0 := token.Position(input, perr.Range.Start)
+		l1, c1 := token.Position(input, perr.Range.End)
+		require.Equal(t, []int{0, 22}, []int{l0, c0})
+		require.Equal(t, []int{0, 23}, []int{l1, c1})
+		require.ErrorContains(t, err, "expected closing tag </div>")
 	})
 }
 

--- a/js/common.go
+++ b/js/common.go
@@ -94,17 +94,17 @@ func ExpectSemi(p *parser.Parser) (tok token.Token, err error) {
 		return
 	case token.RBRACE, token.RPAREN, token.EOF:
 		tok = token.Token{
-			Type:     token.SEMICOLON,
-			Literal:  token.SEMICOLON.Literal(),
-			Position: tok.Position,
+			Type:    token.SEMICOLON,
+			Literal: token.SEMICOLON.Literal(),
+			Offset:  tok.Offset,
 		}
 		return
 	default:
 		if tok.AfterNewline {
 			tok = token.Token{
-				Type:     token.SEMICOLON,
-				Literal:  token.SEMICOLON.Literal(),
-				Position: tok.Position,
+				Type:    token.SEMICOLON,
+				Literal: token.SEMICOLON.Literal(),
+				Offset:  tok.Offset,
 			}
 			return
 		}

--- a/js/stmt_block.go
+++ b/js/stmt_block.go
@@ -31,8 +31,8 @@ func ParseBlockStmt(p *parser.Parser) (node *BlockStmt, err error) {
 			} else {
 				errList = append(errList, err)
 			}
-			if prevToken.Position == p.CurrentToken.Position {
-				// advance position to avoid infinite loop
+			if prevToken.Offset == p.CurrentToken.Offset {
+				// advance offset to avoid infinite loop
 				p.AdvanceToken()
 			}
 			advanceToStmtEnd(p)

--- a/js/stmt_program.go
+++ b/js/stmt_program.go
@@ -27,8 +27,8 @@ func ParseProgram(p *parser.Parser) (node *Program, err error) {
 			} else {
 				errList = append(errList, err)
 			}
-			if prevToken.Position == p.CurrentToken.Position {
-				// advance position to avoid infinite loop
+			if prevToken.Offset == p.CurrentToken.Offset {
+				// advance offset to avoid infinite loop
 				p.AdvanceToken()
 			}
 			advanceToStmtEnd(p)

--- a/jsextended/stmt_dowhile.go
+++ b/jsextended/stmt_dowhile.go
@@ -48,9 +48,9 @@ func ParseDoWhileStmt(p *parser.Parser) (node *DoWhileStmt, err error) {
 		p.AdvanceToken()
 	} else {
 		node.Layout.Semi = token.Token{
-			Type:     token.SEMICOLON,
-			Literal:  token.SEMICOLON.Literal(),
-			Position: p.CurrentToken.Position,
+			Type:    token.SEMICOLON,
+			Literal: token.SEMICOLON.Literal(),
+			Offset:  p.CurrentToken.Offset,
 		}
 	}
 	return

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,17 +1,15 @@
 package parser
 
 import (
-	"strconv"
 	"strings"
-	"unicode/utf8"
 
 	"github.com/xjslang/xjs/ast"
 	"github.com/xjslang/xjs/token"
 )
 
 type Range struct {
-	Start token.Position `json:"start"`
-	End   token.Position `json:"end"`
+	Start int `json:"start"`
+	End   int `json:"end"`
 }
 
 type Error struct {
@@ -20,10 +18,7 @@ type Error struct {
 }
 
 func (err Error) Error() string {
-	start := err.Range.Start
-	return "[line:" + strconv.Itoa(start.Line) +
-		", col:" + strconv.Itoa(start.Column) +
-		"] " + err.Message
+	return err.Message
 }
 
 type ErrorList []error
@@ -148,7 +143,7 @@ func (p *Parser) ExpectLiteral(s string) (token.Token, error) {
 func (p *Parser) ExpectWith(scanner func(s token.Scanner) (string, error)) (tok token.Token, err error) {
 	tok = p.CurrentToken
 	s := p.scanner.(token.ForkableScanner)
-	f := s.ForkFrom(p.CurrentToken.Position)
+	f := s.ForkFrom(p.CurrentToken.Offset)
 	if tok.Literal, err = scanner(f); err != nil {
 		return
 	}
@@ -165,21 +160,14 @@ func (p *Parser) Error(msg string) error {
 
 // ErrorAt returns an error at the given token position.
 func (p *Parser) ErrorAt(tok token.Token, msg string) error {
-	line := tok.Line
-	column := tok.Column
+	offset := tok.Offset
 	if tok.Type == token.EOF {
-		column++
+		offset++
 	}
 	return Error{
 		Range: Range{
-			Start: token.Position{
-				Line:   line,
-				Column: column,
-			},
-			End: token.Position{
-				Line:   line,
-				Column: column + utf8.RuneCountInString(tok.Literal),
-			},
+			Start: offset,
+			End:   offset + len(tok.Literal),
 		},
 		Message: msg,
 	}

--- a/printer/printer.go
+++ b/printer/printer.go
@@ -13,14 +13,12 @@ import (
 const eol = rune(-1)
 
 type Error struct {
-	token.Position
+	Offset  int
 	Message string
 }
 
 func (err Error) Error() string {
-	return "[line:" + strconv.Itoa(err.Line) +
-		", col:" + strconv.Itoa(err.Column) +
-		"] " + err.Message
+	return err.Message
 }
 
 type ErrorList []error
@@ -189,19 +187,7 @@ func (pr *Printer) PrintTrivia(trivia string) {
 }
 
 func (pr *Printer) Error(msg string) error {
-	s := pr.doc.String()
-	line, col := 0, 0
-	for _, c := range s {
-		if c == '\n' {
-			line++
-			col = -1
-		}
-		col++
-	}
-	return ErrorAt(token.Position{
-		Line:   line,
-		Column: col,
-	}, msg)
+	return ErrorAt(pr.doc.Len(), msg)
 }
 
 func (pr *Printer) Errors() ErrorList {

--- a/printer/printer_test.go
+++ b/printer/printer_test.go
@@ -468,7 +468,7 @@ func TestErrorAt(t *testing.T) {
 		switch v := node.(type) {
 		case *js.PrefixOp:
 			if v.Op.Type == spreadOp {
-				return printer.ErrorAt(v.Op.Position, "spread operator is not printable")
+				return printer.ErrorAt(v.Op.Offset, "spread operator is not printable")
 			}
 		}
 		return next(pr, node)
@@ -481,7 +481,10 @@ func TestErrorAt(t *testing.T) {
 	require.NoError(t, err)
 	pr.Print(result)
 	_, err = pr.Output()
-	require.EqualError(t, err, "[line:0, col:8] spread operator is not printable")
+	var perr printer.Error
+	require.ErrorAs(t, err, &perr)
+	require.Equal(t, "spread operator is not printable", perr.Message)
+	require.Equal(t, 8, perr.Offset)
 }
 
 func TestError(t *testing.T) {
@@ -489,10 +492,10 @@ func TestError(t *testing.T) {
 	pr := pb.Build()
 	pr.Print("aaa\nbbb")
 	err := pr.Error("something went wrong")
-	var errPos printer.Error
-	require.ErrorAs(t, err, &errPos)
-	require.Equal(t, "something went wrong", errPos.Message)
-	require.EqualError(t, err, "[line:1, col:3] something went wrong")
+	var perr printer.Error
+	require.ErrorAs(t, err, &perr)
+	require.Equal(t, "something went wrong", perr.Message)
+	require.Equal(t, 7, perr.Offset)
 }
 
 type AsyncFunctionDecl struct {
@@ -575,7 +578,7 @@ func TestPrinterContext(t *testing.T) {
 				ctx := pr.Context()
 				_, ok := ctx["async"]
 				if !ok {
-					return printer.ErrorAt(v.Layout.Await.Position, "await is allowed only inside async functions")
+					return printer.ErrorAt(v.Layout.Await.Offset, "await is allowed only inside async functions")
 				}
 				pr.Line().Print(v.Layout.Await)
 				pr.Space().Print(v.Expr)

--- a/printer/util.go
+++ b/printer/util.go
@@ -2,14 +2,12 @@ package printer
 
 import (
 	"strings"
-
-	"github.com/xjslang/xjs/token"
 )
 
-func ErrorAt(pos token.Position, msg string) error {
+func ErrorAt(offset int, msg string) error {
 	return Error{
-		Position: pos,
-		Message:  msg,
+		Offset:  offset,
+		Message: msg,
 	}
 }
 

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -10,12 +10,11 @@ import (
 const EOF = rune(-1)
 
 type Scanner struct {
-	input        string
-	offset       int
-	line, column int
-	scanner      func(*Scanner) (token.Token, error)
-	currentSize  int
-	currentChar  rune
+	input       string
+	offset      int
+	scanner     func(*Scanner) (token.Token, error)
+	currentSize int
+	currentChar rune
 }
 
 func (s *Scanner) init(input string) {
@@ -26,12 +25,10 @@ func (s *Scanner) init(input string) {
 	s.Reset()
 }
 
-func (s *Scanner) ForkFrom(pos token.Position) token.Scanner {
+func (s *Scanner) ForkFrom(offset int) token.Scanner {
 	newS := &Scanner{
 		input:       s.input,
-		offset:      pos.Offset,
-		line:        pos.Line,
-		column:      pos.Column - 1,
+		offset:      offset,
 		scanner:     s.scanner,
 		currentSize: 0,
 		currentChar: EOF,
@@ -47,8 +44,6 @@ func (s *Scanner) Fork() token.Scanner {
 	newS := &Scanner{
 		input:       s.input,
 		offset:      s.offset,
-		line:        s.line,
-		column:      s.column,
 		currentSize: s.currentSize,
 		currentChar: s.currentChar,
 	}
@@ -63,8 +58,6 @@ func (s *Scanner) Apply(from token.Scanner) {
 	switch v := from.(type) {
 	case *Scanner:
 		s.offset = v.offset
-		s.line = v.line
-		s.column = v.column
 		s.currentSize = v.currentSize
 		s.currentChar = v.currentChar
 	default:
@@ -79,8 +72,6 @@ func (s *Scanner) Reset() {
 	s.offset = 0
 	s.currentSize = 0
 	s.currentChar = EOF
-	s.line = 0
-	s.column = -1
 	s.AdvanceChar()
 }
 
@@ -99,26 +90,8 @@ func (s *Scanner) PeekChar() rune {
 func (s *Scanner) AdvanceChar() {
 	r, size := utf8.DecodeRuneInString(s.input[s.offset:])
 	s.offset += size
-	// covers "\r", "\n" and "\r\n"
-	switch r {
-	case '\r':
-		s.line++
-		s.column = -1
-	case '\n':
-		if s.currentChar != '\r' {
-			s.line++
-			s.column = -1
-		}
-	case utf8.RuneError:
-		if size > 0 {
-			// just an illegal character; keep going
-			s.column++
-		} else {
-			// reached the end of the file
-			r = EOF
-		}
-	default:
-		s.column++
+	if size == 0 && r == utf8.RuneError {
+		r = EOF
 	}
 	s.currentChar, s.currentSize = r, size
 }
@@ -128,14 +101,11 @@ func (s *Scanner) NextToken() token.Token {
 	triviaErr := scanTrivia(s)
 	leadingTrivia := string(s.input[ofs0 : s.offset-s.currentSize])
 	afterNewline := strings.ContainsAny(leadingTrivia, "\n\r")
-	line, column := s.line, s.column
 	startOffset := s.offset - s.currentSize
 
 	tok, err := s.scanner(s)
 	tok.LeadingTrivia = leadingTrivia
 	tok.AfterNewline = afterNewline
-	tok.Line = line
-	tok.Column = max(0, column)
 	tok.Offset = startOffset
 	if triviaErr != nil || err != nil {
 		tok.Type = token.ILLEGAL

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/xjslang/xjs/scanner"
 	"github.com/xjslang/xjs/token"
@@ -57,8 +58,8 @@ func AssertTokens(t *testing.T, toks, expectedToks []token.Token, opts ...TokenC
 			t.Errorf("token %d: expected AfterNewline to be %t, got %t", i, expectedTok.AfterNewline, tok.AfterNewline)
 		case cfg.leadingTrivia && tok.LeadingTrivia != expectedTok.LeadingTrivia:
 			t.Errorf("token %d: expected LeadingTrivia to be %q, got %q", i, expectedTok.LeadingTrivia, tok.LeadingTrivia)
-		case cfg.tokenPosition && (tok.Line != expectedTok.Line || tok.Column != expectedTok.Column):
-			t.Errorf("token %d: expected position to be (%d, %d), got (%d, %d)", i, expectedTok.Line, expectedTok.Column, tok.Line, tok.Column)
+		case cfg.tokenPosition && tok.Offset != expectedTok.Offset:
+			t.Errorf("token %d: expected offset to be %d, got %d", i, expectedTok.Offset, tok.Offset)
 		}
 	}
 }
@@ -107,14 +108,14 @@ func ExampleBuilder_Build() {
 	// Now you can use the scanner
 	for tok := s.NextToken(); tok.Type != token.EOF; tok = s.NextToken() {
 		fmt.Printf(
-			"{Type: %s, Literal: %s, Position: %v}\n",
-			tok.Type.Name(), tok.Literal, tok.Position)
+			"{Type: %s, Literal: %s, Offset: %v}\n",
+			tok.Type.Name(), tok.Literal, tok.Offset)
 	}
 	// Output:
-	// {Type: HASH, Literal: #, Position: {0 0 0}}
-	// {Type: IDENT, Literal: some, Position: {0 1 1}}
-	// {Type: CARET, Literal: ^, Position: {0 6 6}}
-	// {Type: IDENT, Literal: input, Position: {0 7 7}}
+	// {Type: HASH, Literal: #, Offset: 0}
+	// {Type: IDENT, Literal: some, Offset: 1}
+	// {Type: CARET, Literal: ^, Offset: 6}
+	// {Type: IDENT, Literal: input, Offset: 7}
 }
 
 func BenchmarkNextToken(b *testing.B) {
@@ -195,13 +196,13 @@ func TestIdentifier(t *testing.T) {
 func TestTokenPosition(t *testing.T) {
 	input := " aaa   bbb /* block comment*/ ccc\n// comment\rddd\r\ne!\n"
 	assertInputTokens(t, input, []token.Token{
-		{Type: token.IDENT, Literal: "aaa", Position: token.Position{Line: 0, Column: 1}},
-		{Type: token.IDENT, Literal: "bbb", Position: token.Position{Line: 0, Column: 7}},
-		{Type: token.IDENT, Literal: "ccc", Position: token.Position{Line: 0, Column: 30}},
-		{Type: token.IDENT, Literal: "ddd", Position: token.Position{Line: 2, Column: 0}},
-		{Type: token.IDENT, Literal: "e", Position: token.Position{Line: 3, Column: 0}},
-		{Type: token.NOT, Literal: "!", Position: token.Position{Line: 3, Column: 1}},
-		{Type: token.EOF, Position: token.Position{Line: 4, Column: 0}},
+		{Type: token.IDENT, Literal: "aaa", Offset: 1},
+		{Type: token.IDENT, Literal: "bbb", Offset: 7},
+		{Type: token.IDENT, Literal: "ccc", Offset: 30},
+		{Type: token.IDENT, Literal: "ddd", Offset: 45},
+		{Type: token.IDENT, Literal: "e", Offset: 50},
+		{Type: token.NOT, Literal: "!", Offset: 51},
+		{Type: token.EOF, Offset: 53},
 	}, CompareTokenPosition())
 }
 
@@ -487,5 +488,29 @@ func TestSpecialRunes(t *testing.T) {
 		require.Equal(t, token.IDENT, tok.Type)
 		require.Equal(t, input, tok.Literal)
 		require.Equal(t, token.EOF, sc.NextToken().Type)
+	}
+}
+
+func TestPosition(t *testing.T) {
+	input := " aaa   bbb /* block comment*/ ccc\n// comment\rddd\r\ne!\n."
+	positions := []struct{ line, column int }{
+		{0, 1},
+		{0, 7},
+		{0, 30},
+		{2, 0},
+		{3, 0},
+		{3, 1},
+		{4, 0},
+	}
+	sb := scanner.Builder{}
+	s := sb.Build(input)
+	var toks []token.Token
+	for i, tok := 0, s.NextToken(); tok.Type != token.EOF; i, tok = i+1, s.NextToken() {
+		toks = append(toks, tok)
+	}
+	require.Len(t, toks, 7)
+	for i, tok := range toks {
+		l, c := token.Position(input, tok.Offset)
+		assert.Equal(t, [2]int{positions[i].line, positions[i].column}, [2]int{l, c})
 	}
 }

--- a/token/token.go
+++ b/token/token.go
@@ -6,7 +6,7 @@ import (
 )
 
 type ForkableScanner interface {
-	ForkFrom(Position) Scanner
+	ForkFrom(int) Scanner
 	Fork() Scanner
 	Apply(Scanner)
 }
@@ -39,15 +39,9 @@ func (tt Type) Literal() string {
 	return info.literal
 }
 
-type Position struct {
-	Line   int `json:"line"`
-	Column int `json:"column"`
-	Offset int `json:"offset"`
-}
-
 type Token struct {
-	Position
 	Type          Type
+	Offset        int
 	Literal       string
 	LeadingTrivia string
 	AfterNewline  bool

--- a/token/util.go
+++ b/token/util.go
@@ -1,0 +1,38 @@
+package token
+
+import "unicode/utf8"
+
+func Position(src string, offset int) (line, col int) {
+	if offset < 0 {
+		return 0, 0
+	}
+	if offset > len(src) {
+		offset = len(src)
+	}
+	i := 0
+	var prevR rune
+	for i < offset {
+		r, size := utf8.DecodeRuneInString(src[i:])
+		if r == utf8.RuneError && size == 0 {
+			break
+		}
+		if i+size > offset {
+			break
+		}
+		i += size
+		switch r {
+		case '\n':
+			if prevR != '\r' {
+				line++
+				col = 0
+			}
+		case '\r':
+			line++
+			col = 0
+		default:
+			col++
+		}
+		prevR = r
+	}
+	return
+}


### PR DESCRIPTION
This PR introduces a breaking API change.

**How to reproduce**
```bash
git checkout perf/reduce-size-of-token.Token-struct
mage benchCompare main BenchmarkNextToken
```

**Results** (go 1.26.2)
```
goos: darwin
goarch: arm64
pkg: github.com/xjslang/xjs/scanner
cpu: Apple M1 Pro
            │ before.out  │             after.out              │
            │   sec/op    │   sec/op     vs base               │
NextToken-8   3.805m ± 1%   3.568m ± 1%  -6.22% (p=0.000 n=10)

            │ before.out │           after.out            │
            │    B/op    │    B/op     vs base            │
NextToken-8   48.00 ± 0%   48.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

            │ before.out │           after.out            │
            │ allocs/op  │ allocs/op   vs base            │
NextToken-8   3.000 ± 0%   3.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```