### PR TITLE
perf(scanner): optimize NextToken()

### DIFF
--- a/js/common.go
+++ b/js/common.go
@@ -100,7 +100,7 @@ func ExpectSemi(p *parser.Parser) (tok token.Token, err error) {
 		}
 		return
 	default:
-		if tok.AfterNewline {
+		if tok.IsAfterNewline() {
 			tok = token.Token{
 				Type:    token.SEMICOLON,
 				Literal: token.SEMICOLON.Literal(),
@@ -117,5 +117,5 @@ func IsSemi(tok token.Token) bool {
 	if typ := tok.Type; typ == token.SEMICOLON || typ == token.RBRACE || typ == token.RPAREN || typ == token.EOF {
 		return true
 	}
-	return tok.AfterNewline
+	return tok.IsAfterNewline()
 }

--- a/js/stmt_block.go
+++ b/js/stmt_block.go
@@ -71,7 +71,7 @@ func advanceToStmtEnd(p *parser.Parser) {
 			p.AdvanceToken()
 			break
 		}
-		if typ == token.EOF || typ == token.RBRACE || typ == token.LBRACE || p.CurrentToken.AfterNewline {
+		if typ == token.EOF || typ == token.RBRACE || typ == token.LBRACE || p.CurrentToken.IsAfterNewline() {
 			break
 		}
 		p.AdvanceToken()

--- a/js/stmt_break.go
+++ b/js/stmt_break.go
@@ -23,7 +23,7 @@ func ParseBreakStmt(p *parser.Parser) (node *BreakStmt, err error) {
 	if node.Layout.Break, err = p.Expect(BREAK); err != nil {
 		return
 	}
-	if p.CurrentToken.Type == token.IDENT && !p.CurrentToken.AfterNewline {
+	if p.CurrentToken.Type == token.IDENT && !p.CurrentToken.IsAfterNewline() {
 		if node.Label, err = ParseIdent(p); err != nil {
 			return
 		}

--- a/js/stmt_continue.go
+++ b/js/stmt_continue.go
@@ -23,7 +23,7 @@ func ParseContinueStmt(p *parser.Parser) (node *ContinueStmt, err error) {
 	if node.Layout.Continue, err = p.Expect(CONTINUE); err != nil {
 		return
 	}
-	if p.CurrentToken.Type == token.IDENT && !p.CurrentToken.AfterNewline {
+	if p.CurrentToken.Type == token.IDENT && !p.CurrentToken.IsAfterNewline() {
 		if node.Label, err = ParseIdent(p); err != nil {
 			return
 		}

--- a/js/stmt_return.go
+++ b/js/stmt_return.go
@@ -24,7 +24,7 @@ func ParseReturnStmt(p *parser.Parser) (node *ReturnStmt, err error) {
 		return
 	}
 	typ := p.CurrentToken.Type
-	if !p.CurrentToken.AfterNewline && typ != token.EOF && typ != token.SEMICOLON && typ != token.RBRACE {
+	if typ != token.EOF && typ != token.SEMICOLON && typ != token.RBRACE && !p.CurrentToken.IsAfterNewline() {
 		if node.Value, err = p.ParseExpr(); err != nil {
 			return
 		}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -1,7 +1,6 @@
 package scanner
 
 import (
-	"strings"
 	"unicode/utf8"
 
 	"github.com/xjslang/xjs/token"
@@ -100,12 +99,10 @@ func (s *Scanner) NextToken() token.Token {
 	ofs0 := s.offset - s.currentSize
 	triviaErr := scanTrivia(s)
 	leadingTrivia := string(s.input[ofs0 : s.offset-s.currentSize])
-	afterNewline := strings.ContainsAny(leadingTrivia, "\n\r")
 	startOffset := s.offset - s.currentSize
 
 	tok, err := s.scanner(s)
 	tok.LeadingTrivia = leadingTrivia
-	tok.AfterNewline = afterNewline
 	tok.Offset = startOffset
 	if triviaErr != nil || err != nil {
 		tok.Type = token.ILLEGAL

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -13,18 +13,12 @@ import (
 )
 
 type tokenCompareConfig struct {
-	afterNewline  bool
 	leadingTrivia bool
 	tokenPosition bool
+	assertFn      func(token.Token) bool
 }
 
 type TokenCompareOption func(cfg *tokenCompareConfig)
-
-func CompareAfterNewline() TokenCompareOption {
-	return func(cfg *tokenCompareConfig) {
-		cfg.afterNewline = true
-	}
-}
 
 func CompareLeadingTrivia() TokenCompareOption {
 	return func(cfg *tokenCompareConfig) {
@@ -35,6 +29,12 @@ func CompareLeadingTrivia() TokenCompareOption {
 func CompareTokenPosition() TokenCompareOption {
 	return func(cfg *tokenCompareConfig) {
 		cfg.tokenPosition = true
+	}
+}
+
+func CompareAssertFn(assertFn func(token.Token) bool) TokenCompareOption {
+	return func(cfg *tokenCompareConfig) {
+		cfg.assertFn = assertFn
 	}
 }
 
@@ -54,12 +54,12 @@ func AssertTokens(t *testing.T, toks, expectedToks []token.Token, opts ...TokenC
 			t.Errorf("token %d: expected type %v, got %v", i, expectedTok.Type, tok.Type)
 		case tok.Literal != expectedTok.Literal:
 			t.Errorf("token %d: expected %q, got %q", i, expectedTok.Literal, tok.Literal)
-		case cfg.afterNewline && tok.AfterNewline != expectedTok.AfterNewline:
-			t.Errorf("token %d: expected AfterNewline to be %t, got %t", i, expectedTok.AfterNewline, tok.AfterNewline)
 		case cfg.leadingTrivia && tok.LeadingTrivia != expectedTok.LeadingTrivia:
 			t.Errorf("token %d: expected LeadingTrivia to be %q, got %q", i, expectedTok.LeadingTrivia, tok.LeadingTrivia)
 		case cfg.tokenPosition && tok.Offset != expectedTok.Offset:
 			t.Errorf("token %d: expected offset to be %d, got %d", i, expectedTok.Offset, tok.Offset)
+		case cfg.assertFn != nil && !cfg.assertFn(tok):
+			t.Errorf("token %d: custom assertion failed for token %+v", i, tok)
 		}
 	}
 }
@@ -279,9 +279,12 @@ func TestAfterNewline(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			assertInputTokens(t, test.input, []token.Token{
 				{Type: token.IDENT, Literal: "hello"},
-				{Type: token.IDENT, Literal: "world", AfterNewline: true},
+				{Type: token.IDENT, Literal: "world"},
 				{Type: token.EOF},
-			}, CompareAfterNewline())
+			}, CompareAssertFn(func(tok token.Token) bool {
+				wantAfterNewline := tok.Literal == "world"
+				return tok.IsAfterNewline() == wantAfterNewline
+			}))
 		})
 	}
 }
@@ -323,8 +326,10 @@ func TestEmptySinglelineComment(t *testing.T) {
 
 func TestLastLineComment(t *testing.T) {
 	assertInputTokens(t, "// last comment", []token.Token{
-		{Type: token.EOF, Literal: "", AfterNewline: false, LeadingTrivia: "// last comment"},
-	}, CompareLeadingTrivia(), CompareAfterNewline())
+		{Type: token.EOF, Literal: "", LeadingTrivia: "// last comment"},
+	}, CompareLeadingTrivia(), CompareAssertFn(func(tok token.Token) bool {
+		return !tok.IsAfterNewline()
+	}))
 }
 
 func TestScanContinuesAfterNullCharacter(t *testing.T) {

--- a/token/token.go
+++ b/token/token.go
@@ -2,6 +2,7 @@ package token
 
 import (
 	"strconv"
+	"strings"
 	"sync"
 )
 
@@ -44,7 +45,10 @@ type Token struct {
 	Offset        int
 	Literal       string
 	LeadingTrivia string
-	AfterNewline  bool
+}
+
+func (t Token) IsAfterNewline() bool {
+	return strings.ContainsAny(t.LeadingTrivia, "\n\r")
 }
 
 const (


### PR DESCRIPTION
This PR introduces a breaking API change.

**How to reproduce**
```bash
git checkout perf/reduce-size-of-token.Token-struct
mage benchCompare main BenchmarkNextToken
```
**Results** (go 1.26.2)
```
goos: darwin
goarch: arm64
pkg: github.com/xjslang/xjs/scanner
cpu: Apple M1 Pro
            │ before.out  │              after.out              │
            │   sec/op    │   sec/op     vs base                │
NextToken-8   3.637m ± 1%   3.075m ± 0%  -15.46% (p=0.000 n=10)

            │ before.out │           after.out            │
            │    B/op    │    B/op     vs base            │
NextToken-8   48.00 ± 0%   48.00 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

            │ before.out │           after.out            │
            │ allocs/op  │ allocs/op   vs base            │
NextToken-8   3.000 ± 0%   3.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
Already on 'perf/optimize-NextToken-func'
```