### PR TITLE
perf(printer): optimize printTrivia()

### DIFF
--- a/printer/printer.go
+++ b/printer/printer.go
@@ -152,16 +152,74 @@ func (pr *Printer) printTrivia(trivia string) {
 	if pr.isCompact {
 		return
 	}
-	lines := splitTrivia(trivia)
 	es, e := pr.ensureChar, pr.ensure
-	for _, line := range lines {
-		if line == "\n" {
-			pr.writeRune('\n')
-			continue
+	offset := 0
+	r, size := rune(0), 0
+mainloop:
+	for {
+		// ignore spaces on the left
+		for {
+			r, size = utf8.DecodeRuneInString(trivia[offset:])
+			if r == utf8.RuneError {
+				break mainloop
+			}
+			offset += size
+			if r != ' ' && r != '\t' {
+				break
+			}
 		}
-		pr.printSpaceIfNeeded()
-		pr.printIndentIfNeeded()
-		pr.writeString(line)
+		switch r {
+		case '\n':
+			// scan newline
+			pr.writeRune('\n')
+			continue mainloop
+		case '/':
+			// scan comment
+			o0 := offset
+			pr.printSpaceIfNeeded()
+			pr.printIndentIfNeeded()
+			pr.writeRune('/')
+			r, size = utf8.DecodeRuneInString(trivia[offset:])
+			if r == utf8.RuneError {
+				break mainloop
+			}
+			offset += size
+			switch r {
+			case '/':
+				// scan line comments
+				for {
+					r, size = utf8.DecodeRuneInString(trivia[offset:])
+					if r == utf8.RuneError {
+						break
+					}
+					if r == '\n' {
+						break
+					}
+					offset += size
+				}
+				pr.writeString(trivia[o0:offset])
+			case '*':
+				// scan block comment
+				for {
+					r, size = utf8.DecodeRuneInString(trivia[offset:])
+					if r == utf8.RuneError {
+						break
+					}
+					offset += size
+					if r == '*' {
+						r, size = utf8.DecodeRuneInString(trivia[offset:])
+						if r == utf8.RuneError {
+							break
+						}
+						offset += size
+						if r == '/' {
+							break
+						}
+					}
+				}
+				pr.writeString(trivia[o0:offset])
+			}
+		}
 	}
 	pr.ensureChar, pr.ensure = es, e
 }

--- a/printer/util.go
+++ b/printer/util.go
@@ -1,9 +1,5 @@
 package printer
 
-import (
-	"strings"
-)
-
 func ErrorAt(offset int, msg string) error {
 	return Error{
 		Offset:  offset,
@@ -17,44 +13,4 @@ func isNewLine(r rune) bool {
 
 func isWhitespace(r rune) bool {
 	return isNewLine(r) || r == ' ' || r == '\t'
-}
-
-func splitTrivia(trivia string) []string {
-	var lines []string
-	sb := strings.Builder{}
-	skipSpaces := true
-	skipLF := false
-	for _, c := range trivia {
-		if skipLF {
-			skipLF = false
-			if c == '\n' {
-				continue
-			}
-		}
-		if skipSpaces && (c == ' ' || c == '\t') {
-			continue
-		}
-		switch c {
-		case '\r':
-			sb.WriteRune('\n') // normalize CR/CRLF to LF
-			lines = append(lines, sb.String())
-			sb.Reset()
-			skipSpaces = true
-			skipLF = true
-			continue
-		case '\n':
-			sb.WriteRune('\n')
-			lines = append(lines, sb.String())
-			sb.Reset()
-			skipSpaces = true
-			continue
-		default:
-			sb.WriteRune(c)
-			skipSpaces = false
-		}
-	}
-	if s := sb.String(); len(s) > 0 {
-		lines = append(lines, strings.TrimRight(s, " "))
-	}
-	return lines
 }


### PR DESCRIPTION
**How to reproduce**
```bash
mage benchCompare main BenchmarkPrint
```

**Results** (go 1.26.2)
```
goos: darwin
goarch: arm64
pkg: github.com/xjslang/xjs/jsextended
cpu: Apple M1 Pro
        │ before.out  │              after.out              │
        │   sec/op    │   sec/op     vs base                │
Print-8   2.693m ± 3%   1.961m ± 2%  -27.17% (p=0.000 n=10)

        │  before.out  │              after.out               │
        │     B/op     │     B/op      vs base                │
Print-8   1.872Mi ± 0%   1.615Mi ± 0%  -13.71% (p=0.000 n=10)

        │ before.out  │              after.out              │
        │  allocs/op  │  allocs/op   vs base                │
Print-8   41.32k ± 0%   24.61k ± 0%  -40.45% (p=0.000 n=10)
```